### PR TITLE
Add fluidattacks configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Package.resolved
 
 # mdBook
 book/
+
+# Fluidattacks scanner
+fluidscan-results.sarif

--- a/config/fluidattacks/config.yaml
+++ b/config/fluidattacks/config.yaml
@@ -1,0 +1,25 @@
+---
+# Taken from: https://appdefensealliance.dev/casa/tier-2/ast-guide/static-scan
+# as that is out of date, updated to the latest version of the scanner.
+# https://help.fluidattacks.com/portal/en/kb/articles/validate-casa-tier-2-requirements
+namespace: thunderbird-ios
+working_dir: /repo
+language: EN
+output:
+  file_path: /repo/fluidscan-results.sarif
+  format: SARIF
+sast:
+  include:
+    - .
+  exclude:
+    - glob(**/build/**)
+    - glob(**/test/**)
+    - glob(docs/**)
+sca:
+  include:
+    - .
+  exclude:
+    - glob(**/test/**)
+    - glob(docs/**)
+file_size_limit: false
+tracing_opt_out: true


### PR DESCRIPTION
The config file was missing. A few things to consider:

* The build/test paths are not accurate. What should go here?
* The config file location might not fit into the structure well. Where is a good place for this type of config file? Ideally we want to structure the repo in a way that we can separate responsibilities, e.g. the build/release team could be responsible for all CI scripts and their config.