### PR TITLE
Persist server passwords in keychain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-#       - name: Resolve Swift packages
-#         run: swift package resolve
+        - name: Resolve Swift packages
+          run: swift package resolve
         - name: Build and analyze
           run: xcodebuild clean build analyze -workspace Thunderbird.xcworkspace -scheme Thunderbird -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'
         - name: Run tests in iPhone 16 Simulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        - name: Resolve Swift packages
-          run: swift package resolve
+        - name: Resolve package dependencies
+          run: xcodebuild -resolvePackageDependencies -workspace Thunderbird.xcworkspace -scheme Thunderbird
         - name: Build and analyze
           run: xcodebuild clean build analyze -workspace Thunderbird.xcworkspace -scheme Thunderbird -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'
         - name: Run tests in iPhone 16 Simulator

--- a/Mail/Package.swift
+++ b/Mail/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Mail/Package.swift
+++ b/Mail/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package: Package = Package(name: "Mail", platforms: [
+        .macOS(.v15),
+        .iOS(.v18),
+        .watchOS(.v11)
+    ], products: [
+        .library(name: "Account", targets: [
+            "Account"
+        ])
+    ], targets: [
+        .target(name: "Account"),
+        .testTarget(name: "AccountTests", dependencies: [
+            "Account"
+        ])
+    ])

--- a/Mail/Package.swift
+++ b/Mail/Package.swift
@@ -2,17 +2,25 @@
 
 import PackageDescription
 
-let package: Package = Package(name: "Mail", platforms: [
+let package: Package = Package(
+    name: "Mail",
+    platforms: [
         .macOS(.v15),
         .iOS(.v18),
         .watchOS(.v11)
-    ], products: [
-        .library(name: "Account", targets: [
-            "Account"
-        ])
-    ], targets: [
+    ],
+    products: [
+        .library(
+            name: "Account",
+            targets: [
+                "Account"
+            ])
+    ],
+    targets: [
         .target(name: "Account"),
-        .testTarget(name: "AccountTests", dependencies: [
-            "Account"
-        ])
+        .testTarget(
+            name: "AccountTests",
+            dependencies: [
+                "Account"
+            ])
     ])

--- a/Mail/Sources/Account/Account.swift
+++ b/Mail/Sources/Account/Account.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Account: Codable, Identifiable {
+    public let name: String
+    public let incomingServer: IncomingServer
+    
+    public init(name: String, incomingServer: IncomingServer, id: UUID = UUID()) {
+        self.name = name
+        self.incomingServer = incomingServer
+        self.id = id
+    }
+    
+    // MARK: Identifiable
+    public let id: UUID
+}

--- a/Mail/Sources/Account/Account.swift
+++ b/Mail/Sources/Account/Account.swift
@@ -3,13 +3,13 @@ import Foundation
 public struct Account: Codable, Identifiable {
     public let name: String
     public let incomingServer: IncomingServer
-    
+
     public init(name: String, incomingServer: IncomingServer, id: UUID = UUID()) {
         self.name = name
         self.incomingServer = incomingServer
         self.id = id
     }
-    
+
     // MARK: Identifiable
     public let id: UUID
 }

--- a/Mail/Sources/Account/AuthenticationType.swift
+++ b/Mail/Sources/Account/AuthenticationType.swift
@@ -4,7 +4,7 @@ public enum AuthenticationType: String, Codable, CaseIterable, CustomStringConve
     case tlsCertificate = "TLS certificate"
     case oAuth2 = "OAuth2"
     case none
-    
+
     // MARK: CustomStringConvertible
     public var description: String { rawValue }
 }

--- a/Mail/Sources/Account/AuthenticationType.swift
+++ b/Mail/Sources/Account/AuthenticationType.swift
@@ -1,0 +1,10 @@
+public enum AuthenticationType: String, Codable, CaseIterable, CustomStringConvertible {
+    case password
+    case passwordEncrypted = "encrypted password"
+    case tlsCertificate = "TLS certificate"
+    case oAuth2 = "OAuth2"
+    case none
+    
+    // MARK: CustomStringConvertible
+    public var description: String { rawValue }
+}

--- a/Mail/Sources/Account/ConnectionSecurity.swift
+++ b/Mail/Sources/Account/ConnectionSecurity.swift
@@ -2,7 +2,7 @@ public enum ConnectionSecurity: String, Codable, CaseIterable, CustomStringConve
     case startTLS = "STARTTLS"
     case tls = "SSL/TLS"
     case none
-    
+
     // MARK: CustomStringConvertible
     public var description: String { rawValue }
 }

--- a/Mail/Sources/Account/ConnectionSecurity.swift
+++ b/Mail/Sources/Account/ConnectionSecurity.swift
@@ -1,0 +1,8 @@
+public enum ConnectionSecurity: String, Codable, CaseIterable, CustomStringConvertible {
+    case startTLS = "STARTTLS"
+    case tls = "SSL/TLS"
+    case none
+    
+    // MARK: CustomStringConvertible
+    public var description: String { rawValue }
+}

--- a/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
+++ b/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
@@ -12,7 +12,7 @@ extension URLCredentialStorage {
         if let password, !password.isEmpty {
             set(URLCredential(user: user, password: password, persistence: .permanent), for: space)
         } else if let credential: URLCredential = credentials(for: space)?[user] {
-            remove(credential, for: space) // Remove existing credential on nil password
+            remove(credential, for: space)  // Remove existing credential on nil password
         }
     }
 

--- a/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
+++ b/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 extension URLCredentialStorage {
-    
+
     /// Retrieve password for a given user name and protection space.
     func password(for user: String, space: URLProtectionSpace = .account) -> String? {
         credentials(for: space)?[user]?.password
     }
-    
+
     /// Set or nil password for a given user name and protection space.
     func set(_ password: String?, for user: String, space: URLProtectionSpace = .account) {
         if let password, !password.isEmpty {
@@ -15,7 +15,7 @@ extension URLCredentialStorage {
             remove(credential, for: space) // Remove existing credential on nil password
         }
     }
-    
+
     /// Remove all credentials for a given protection space.
     func removeCredentials(for space: URLProtectionSpace) {
         for credential in (credentials(for: space) ?? [:]).values {

--- a/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
+++ b/Mail/Sources/Account/Foundation/URLCredentialStorage.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension URLCredentialStorage {
+    
+    /// Retrieve password for a given user name and protection space.
+    func password(for user: String, space: URLProtectionSpace = .account) -> String? {
+        credentials(for: space)?[user]?.password
+    }
+    
+    /// Set or nil password for a given user name and protection space.
+    func set(_ password: String?, for user: String, space: URLProtectionSpace = .account) {
+        if let password, !password.isEmpty {
+            set(URLCredential(user: user, password: password, persistence: .permanent), for: space)
+        } else if let credential: URLCredential = credentials(for: space)?[user] {
+            remove(credential, for: space) // Remove existing credential on nil password
+        }
+    }
+    
+    /// Remove all credentials for a given protection space.
+    func removeCredentials(for space: URLProtectionSpace) {
+        for credential in (credentials(for: space) ?? [:]).values {
+            remove(credential, for: space)
+        }
+    }
+}

--- a/Mail/Sources/Account/Foundation/URLProtectionSpace.swift
+++ b/Mail/Sources/Account/Foundation/URLProtectionSpace.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension URLProtectionSpace {
+    
+    ///  Named secure realm for Thunderbird accounts
+    static let account: URLProtectionSpace = URLProtectionSpace(host: "thunderbird.net")
+    
+    convenience init(host: String) {
+        self.init(host: host, port: 0, protocol: "https", realm: nil, authenticationMethod: nil)
+    }
+}

--- a/Mail/Sources/Account/Foundation/URLProtectionSpace.swift
+++ b/Mail/Sources/Account/Foundation/URLProtectionSpace.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 extension URLProtectionSpace {
-    
+
     ///  Named secure realm for Thunderbird accounts
     static let account: URLProtectionSpace = URLProtectionSpace(host: "thunderbird.net")
-    
+
     convenience init(host: String) {
         self.init(host: host, port: 0, protocol: "https", realm: nil, authenticationMethod: nil)
     }

--- a/Mail/Sources/Account/IncomingServer.swift
+++ b/Mail/Sources/Account/IncomingServer.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public struct IncomingServer: Codable, Identifiable {
+    public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible {
+        case imap = "IMAP"
+        
+        // MARK: CustomStringConvertible
+        public var description: String { rawValue }
+    }
+    
+    public let serverProtocol: ServerProtocol
+    public let connectionSecurity: ConnectionSecurity
+    public let authenticationType: AuthenticationType
+    public let username: String
+    public let hostname: String
+    public let port: Int
+    
+    public var password: String? {
+        URLCredentialStorage.shared.password(for: user)
+    }
+    
+    public init(
+        serverProtocol: ServerProtocol,
+        connectionSecurity: ConnectionSecurity = .none,
+        authenticationType: AuthenticationType = .none,
+        username: String,
+        password: String? = nil,
+        hostname: String,
+        port: Int? = nil,
+        id: UUID = UUID()
+    ) {
+        self.serverProtocol = serverProtocol
+        self.connectionSecurity = connectionSecurity
+        self.authenticationType = authenticationType
+        self.username = username
+        self.hostname = hostname
+        switch connectionSecurity {
+        case .tls:
+            self.port = port ?? 993 // Secure IMAP
+        default:
+            self.port = port ?? 143 // IMAP
+        }
+        self.id = id
+        
+        // Save password in keychain
+        URLCredentialStorage.shared.set(password, for: user)
+    }
+    
+    var user: String { // Generate unique keychain user label: "user@example.com IMAP:E621E1F8"
+        "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
+    }
+    
+    // MARK: Identifiable
+    public let id: UUID
+}

--- a/Mail/Sources/Account/IncomingServer.swift
+++ b/Mail/Sources/Account/IncomingServer.swift
@@ -3,22 +3,22 @@ import Foundation
 public struct IncomingServer: Codable, Identifiable {
     public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible {
         case imap = "IMAP"
-        
+
         // MARK: CustomStringConvertible
         public var description: String { rawValue }
     }
-    
+
     public let serverProtocol: ServerProtocol
     public let connectionSecurity: ConnectionSecurity
     public let authenticationType: AuthenticationType
     public let username: String
     public let hostname: String
     public let port: Int
-    
+
     public var password: String? {
         URLCredentialStorage.shared.password(for: user)
     }
-    
+
     public init(
         serverProtocol: ServerProtocol,
         connectionSecurity: ConnectionSecurity = .none,
@@ -41,15 +41,15 @@ public struct IncomingServer: Codable, Identifiable {
             self.port = port ?? 143 // IMAP
         }
         self.id = id
-        
+
         // Save password in keychain
         URLCredentialStorage.shared.set(password, for: user)
     }
-    
+
     var user: String { // Generate unique keychain user label: "user@example.com IMAP:E621E1F8"
         "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
     }
-    
+
     // MARK: Identifiable
     public let id: UUID
 }

--- a/Mail/Sources/Account/IncomingServer.swift
+++ b/Mail/Sources/Account/IncomingServer.swift
@@ -36,9 +36,9 @@ public struct IncomingServer: Codable, Identifiable {
         self.hostname = hostname
         switch connectionSecurity {
         case .tls:
-            self.port = port ?? 993 // Secure IMAP
+            self.port = port ?? 993  // Secure IMAP
         default:
-            self.port = port ?? 143 // IMAP
+            self.port = port ?? 143  // IMAP
         }
         self.id = id
 
@@ -46,7 +46,7 @@ public struct IncomingServer: Codable, Identifiable {
         URLCredentialStorage.shared.set(password, for: user)
     }
 
-    var user: String { // Generate unique keychain user label: "user@example.com IMAP:E621E1F8"
+    var user: String {  // Generate unique keychain user label: "user@example.com IMAP:E621E1F8"
         "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
     }
 

--- a/Mail/Sources/Account/OutgoingServer.swift
+++ b/Mail/Sources/Account/OutgoingServer.swift
@@ -34,14 +34,14 @@ public struct OutgoingServer: Codable, Identifiable {
         self.authenticationType = authenticationType
         self.username = username
         self.hostname = hostname
-        self.port = port ?? 25 // SMTP default
+        self.port = port ?? 25  // SMTP default
         self.id = id
 
         // Save password in keychain
         URLCredentialStorage.shared.set(password, for: user)
     }
 
-    var user: String { // Generate unique keychain user label: "user@example.com SMTP:E621E1F8"
+    var user: String {  // Generate unique keychain user label: "user@example.com SMTP:E621E1F8"
         "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
     }
 

--- a/Mail/Sources/Account/OutgoingServer.swift
+++ b/Mail/Sources/Account/OutgoingServer.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct OutgoingServer: Codable, Identifiable {
+    public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible {
+        case smtp = "SMTP"
+        
+        // MARK: CustomStringConvertible
+        public var description: String { rawValue }
+    }
+    
+    public let serverProtocol: ServerProtocol
+    public let connectionSecurity: ConnectionSecurity
+    public let authenticationType: AuthenticationType
+    public let username: String
+    public let hostname: String
+    public let port: Int
+    
+    public var password: String? {
+        URLCredentialStorage.shared.password(for: user)
+    }
+    
+    public init(
+        serverProtocol: ServerProtocol = .smtp,
+        connectionSecurity: ConnectionSecurity = .none,
+        authenticationType: AuthenticationType = .none,
+        username: String,
+        password: String? = nil,
+        hostname: String,
+        port: Int? = nil,
+        id: UUID = UUID()
+    ) {
+        self.serverProtocol = serverProtocol
+        self.connectionSecurity = connectionSecurity
+        self.authenticationType = authenticationType
+        self.username = username
+        self.hostname = hostname
+        self.port = port ?? 25 // SMTP default
+        self.id = id
+        
+        // Save password in keychain
+        URLCredentialStorage.shared.set(password, for: user)
+    }
+    
+    var user: String { // Generate unique keychain user label: "user@example.com SMTP:E621E1F8"
+        "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
+    }
+    
+    // MARK: Identifiable
+    public let id: UUID
+}

--- a/Mail/Sources/Account/OutgoingServer.swift
+++ b/Mail/Sources/Account/OutgoingServer.swift
@@ -3,22 +3,22 @@ import Foundation
 public struct OutgoingServer: Codable, Identifiable {
     public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible {
         case smtp = "SMTP"
-        
+
         // MARK: CustomStringConvertible
         public var description: String { rawValue }
     }
-    
+
     public let serverProtocol: ServerProtocol
     public let connectionSecurity: ConnectionSecurity
     public let authenticationType: AuthenticationType
     public let username: String
     public let hostname: String
     public let port: Int
-    
+
     public var password: String? {
         URLCredentialStorage.shared.password(for: user)
     }
-    
+
     public init(
         serverProtocol: ServerProtocol = .smtp,
         connectionSecurity: ConnectionSecurity = .none,
@@ -36,15 +36,15 @@ public struct OutgoingServer: Codable, Identifiable {
         self.hostname = hostname
         self.port = port ?? 25 // SMTP default
         self.id = id
-        
+
         // Save password in keychain
         URLCredentialStorage.shared.set(password, for: user)
     }
-    
+
     var user: String { // Generate unique keychain user label: "user@example.com SMTP:E621E1F8"
         "\(username) \(serverProtocol):\(id.uuidString.components(separatedBy: "-")[0])"
     }
-    
+
     // MARK: Identifiable
     public let id: UUID
 }

--- a/Mail/Tests/AccountTests/AccountTests.swift
+++ b/Mail/Tests/AccountTests/AccountTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Account
+
+struct AccountTests {
+    
+}

--- a/Mail/Tests/AccountTests/AccountTests.swift
+++ b/Mail/Tests/AccountTests/AccountTests.swift
@@ -1,6 +1,0 @@
-import Testing
-@testable import Account
-
-struct AccountTests {
-    
-}

--- a/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
+++ b/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
@@ -25,9 +25,9 @@ struct URLCredentialStorageTests {
         URLCredentialStorage.shared.removeCredentials(for: space)
         URLCredentialStorage.shared.set(URLCredential(user: "user@netscape.net", password: "correct horse battery staple", persistence: .permanent), for: space)
         URLCredentialStorage.shared.set(URLCredential(user: "username@icloud.com", password: "abcd1234", persistence: .forSession), for: space)
-        URLCredentialStorage.shared.set(URLCredential(user: "username@icloud.com", password: "abcd1234", persistence: .permanent), for: space) // Duplicate credential
+        URLCredentialStorage.shared.set(URLCredential(user: "username@icloud.com", password: "abcd1234", persistence: .permanent), for: space)  // Duplicate credential
         URLCredentialStorage.shared.set(URLCredential(user: "admin@example.com", password: "gAAAAUTHtoKENb3arerJWe", persistence: .forSession), for: space)
-        #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 3) // Credentials are equatable and de-duplicated by by `username`
+        #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 3)  // Credentials are equatable and de-duplicated by by `username`
         #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 3)
         URLCredentialStorage.shared.removeCredentials(for: space)
         #expect(URLCredentialStorage.shared.credentials(for: space) == nil)
@@ -36,7 +36,7 @@ struct URLCredentialStorageTests {
 
 var isKeychainAvailable: Bool {
     #if os(macOS)
-    true // Keychain only accessible (to non-hosted tests) on macOS
+    true  // Keychain only accessible (to non-hosted tests) on macOS
     #else
     false
     #endif

--- a/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
+++ b/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import Account
+
+struct URLCredentialStorageTests {
+    @Test(.enabled(if: isKeychainAvailable)) func password() {
+        let space: URLProtectionSpace = URLProtectionSpace(host: "com.example")
+        let credential: URLCredential = URLCredential(user: "user@netscape.net", password: "essmI1-vudwic-wwanar", persistence: .forSession)
+        URLCredentialStorage.shared.set(credential, for: space)
+        #expect(URLCredentialStorage.shared.password(for: credential.user!, space: space) == "essmI1-vudwic-wwanar")
+        URLCredentialStorage.shared.removeCredentials(for: space)
+        #expect(URLCredentialStorage.shared.password(for: credential.user!, space: space) == nil)
+    }
+    
+    @Test(.enabled(if: isKeychainAvailable)) func setPassword() {
+        let space: URLProtectionSpace = URLProtectionSpace(host: "org.example")
+        URLCredentialStorage.shared.set("zemhu8-omdRiz-zisbov", for: "user.name@icloud.com", space: space)
+        #expect(URLCredentialStorage.shared.password(for: "user.name@icloud.com", space: space) == "zemhu8-omdRiz-zisbov")
+        URLCredentialStorage.shared.set(nil, for: "user.name@icloud.com", space: space)
+        #expect(URLCredentialStorage.shared.password(for: "user.name@icloud.com", space: space) == nil)
+    }
+    
+    @Test(.enabled(if: isKeychainAvailable)) func removeCredentials() {
+        let space: URLProtectionSpace = URLProtectionSpace(host: "net.example")
+        URLCredentialStorage.shared.removeCredentials(for: space)
+        URLCredentialStorage.shared.set(URLCredential(user: "user@netscape.net", password: "correct horse battery staple", persistence: .permanent), for: space)
+        URLCredentialStorage.shared.set(URLCredential(user: "username@icloud.com", password: "abcd1234", persistence: .forSession), for: space)
+        URLCredentialStorage.shared.set(URLCredential(user: "username@icloud.com", password: "abcd1234", persistence: .permanent), for: space) // Duplicate credential
+        URLCredentialStorage.shared.set(URLCredential(user: "admin@example.com", password: "gAAAAUTHtoKENb3arerJWe", persistence: .forSession), for: space)
+        #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 3) // Credentials are equatable and de-duplicated by by `username`
+        #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 3)
+        URLCredentialStorage.shared.removeCredentials(for: space)
+        #expect(URLCredentialStorage.shared.credentials(for: space) == nil)
+    }
+}
+
+var isKeychainAvailable: Bool {
+#if os(macOS)
+    true // Keychain only accessible (to non-hosted tests) on macOS
+#else
+    false
+#endif
+}

--- a/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
+++ b/Mail/Tests/AccountTests/FoundationTests/URLCredentialStorageTests.swift
@@ -11,7 +11,7 @@ struct URLCredentialStorageTests {
         URLCredentialStorage.shared.removeCredentials(for: space)
         #expect(URLCredentialStorage.shared.password(for: credential.user!, space: space) == nil)
     }
-    
+
     @Test(.enabled(if: isKeychainAvailable)) func setPassword() {
         let space: URLProtectionSpace = URLProtectionSpace(host: "org.example")
         URLCredentialStorage.shared.set("zemhu8-omdRiz-zisbov", for: "user.name@icloud.com", space: space)
@@ -19,7 +19,7 @@ struct URLCredentialStorageTests {
         URLCredentialStorage.shared.set(nil, for: "user.name@icloud.com", space: space)
         #expect(URLCredentialStorage.shared.password(for: "user.name@icloud.com", space: space) == nil)
     }
-    
+
     @Test(.enabled(if: isKeychainAvailable)) func removeCredentials() {
         let space: URLProtectionSpace = URLProtectionSpace(host: "net.example")
         URLCredentialStorage.shared.removeCredentials(for: space)
@@ -35,9 +35,9 @@ struct URLCredentialStorageTests {
 }
 
 var isKeychainAvailable: Bool {
-#if os(macOS)
+    #if os(macOS)
     true // Keychain only accessible (to non-hosted tests) on macOS
-#else
+    #else
     false
-#endif
+    #endif
 }

--- a/Mail/Tests/AccountTests/FoundationTests/URLProtectionSpaceTests.swift
+++ b/Mail/Tests/AccountTests/FoundationTests/URLProtectionSpaceTests.swift
@@ -1,0 +1,9 @@
+import Testing
+import Foundation
+@testable import Account
+
+struct URLProtectionSpaceTests {
+    @Test func account() {
+        #expect(URLProtectionSpace.account.host == "thunderbird.net")
+    }
+}

--- a/Mail/Tests/AccountTests/IncomingServerTests.swift
+++ b/Mail/Tests/AccountTests/IncomingServerTests.swift
@@ -5,22 +5,24 @@ import Foundation
 struct IncomingServerTests {
     @Test(.enabled(if: isKeychainAvailable)) func password() {
         let id: UUID = UUID()
-        #expect(IncomingServer(
-            serverProtocol: .imap,
-            username: "password@example.com",
-            password: "zemhu8-omdRiz-zisbov",
-            hostname: "imap.example.com",
-            id: id
-        ).password == "zemhu8-omdRiz-zisbov")
-        #expect(IncomingServer(
-            serverProtocol: .imap,
-            username: "password@example.com",
-            password: nil,
-            hostname: "imap.example.com",
-            id: id
-        ).password == nil)
+        #expect(
+            IncomingServer(
+                serverProtocol: .imap,
+                username: "password@example.com",
+                password: "zemhu8-omdRiz-zisbov",
+                hostname: "imap.example.com",
+                id: id
+            ).password == "zemhu8-omdRiz-zisbov")
+        #expect(
+            IncomingServer(
+                serverProtocol: .imap,
+                username: "password@example.com",
+                password: nil,
+                hostname: "imap.example.com",
+                id: id
+            ).password == nil)
     }
-    
+
     @Test func user() {
         let server: IncomingServer = IncomingServer(
             serverProtocol: .imap,

--- a/Mail/Tests/AccountTests/IncomingServerTests.swift
+++ b/Mail/Tests/AccountTests/IncomingServerTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import Account
+
+struct IncomingServerTests {
+    @Test(.enabled(if: isKeychainAvailable)) func password() {
+        let id: UUID = UUID()
+        #expect(IncomingServer(
+            serverProtocol: .imap,
+            username: "password@example.com",
+            password: "zemhu8-omdRiz-zisbov",
+            hostname: "imap.example.com",
+            id: id
+        ).password == "zemhu8-omdRiz-zisbov")
+        #expect(IncomingServer(
+            serverProtocol: .imap,
+            username: "password@example.com",
+            password: nil,
+            hostname: "imap.example.com",
+            id: id
+        ).password == nil)
+    }
+    
+    @Test func user() {
+        let server: IncomingServer = IncomingServer(
+            serverProtocol: .imap,
+            username: "user@example.com",
+            password: nil,
+            hostname: "imap.example.com"
+        )
+        let id: [String] = server.id.uuidString.components(separatedBy: "-")
+        #expect(server.user == "user@example.com IMAP:\(id[0])")
+    }
+}

--- a/Mail/Tests/AccountTests/OutgoingServerTests.swift
+++ b/Mail/Tests/AccountTests/OutgoingServerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import Foundation
+@testable import Account
+
+struct OutgoingServerTests {
+    @Test(.enabled(if: isKeychainAvailable)) func password() {
+        let id: UUID = UUID()
+        #expect(OutgoingServer(
+            username: "password@example.com",
+            password: "gAAAAUTHtoKENb3arerJWe",
+            hostname: "smtp.example.com",
+            id: id
+        ).password == "gAAAAUTHtoKENb3arerJWe")
+        #expect(OutgoingServer(
+            username: "password@example.com",
+            password: nil,
+            hostname: "smtp.example.com",
+            id: id
+        ).password == nil)
+    }
+    
+    @Test func user() {
+        let server: OutgoingServer = OutgoingServer(
+            username: "user@example.com",
+            password: nil,
+            hostname: "smtp.example.com"
+        )
+        let id: [String] = server.id.uuidString.components(separatedBy: "-")
+        #expect(server.user == "user@example.com SMTP:\(id[0])")
+    }
+}

--- a/Mail/Tests/AccountTests/OutgoingServerTests.swift
+++ b/Mail/Tests/AccountTests/OutgoingServerTests.swift
@@ -5,20 +5,22 @@ import Foundation
 struct OutgoingServerTests {
     @Test(.enabled(if: isKeychainAvailable)) func password() {
         let id: UUID = UUID()
-        #expect(OutgoingServer(
-            username: "password@example.com",
-            password: "gAAAAUTHtoKENb3arerJWe",
-            hostname: "smtp.example.com",
-            id: id
-        ).password == "gAAAAUTHtoKENb3arerJWe")
-        #expect(OutgoingServer(
-            username: "password@example.com",
-            password: nil,
-            hostname: "smtp.example.com",
-            id: id
-        ).password == nil)
+        #expect(
+            OutgoingServer(
+                username: "password@example.com",
+                password: "gAAAAUTHtoKENb3arerJWe",
+                hostname: "smtp.example.com",
+                id: id
+            ).password == "gAAAAUTHtoKENb3arerJWe")
+        #expect(
+            OutgoingServer(
+                username: "password@example.com",
+                password: nil,
+                hostname: "smtp.example.com",
+                id: id
+            ).password == nil)
     }
-    
+
     @Test func user() {
         let server: OutgoingServer = OutgoingServer(
             username: "user@example.com",

--- a/Thunderbird.xctestplan
+++ b/Thunderbird.xctestplan
@@ -13,11 +13,17 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Thunderbird.xcodeproj",
         "identifier" : "1521D8232D9C4D6300C4DFDF",
         "name" : "ThunderbirdTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Mail",
+        "identifier" : "AccountTests",
+        "name" : "AccountTests"
       }
     }
   ],

--- a/Thunderbird.xcworkspace/contents.xcworkspacedata
+++ b/Thunderbird.xcworkspace/contents.xcworkspacedata
@@ -8,8 +8,11 @@
       location = "group:Thunderbird/Thunderbird.xcodeproj">
    </FileRef>
    <FileRef
-         location = "group:Thunderbird.xctestplan">
-      </FileRef>
+      location = "group:Thunderbird.xctestplan">
+   </FileRef>
+   <FileRef
+      location = "group:Mail">
+   </FileRef>
    <FileRef
       location = "group:docs">
    </FileRef>

--- a/Thunderbird/Thunderbird.xcodeproj/project.pbxproj
+++ b/Thunderbird/Thunderbird.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		152E827A2DC43AF700FB787B /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = 152E82792DC43AF700FB787B /* Account */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		1521D8252D9C4D6300C4DFDF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -39,6 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				152E827A2DC43AF700FB787B /* Account in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +95,7 @@
 			);
 			name = Thunderbird;
 			packageProductDependencies = (
+				152E82792DC43AF700FB787B /* Account */,
 			);
 			productName = Thunderbird;
 			productReference = 1521D8162D9C4D6200C4DFDF /* Thunderbird.app */;
@@ -148,6 +154,9 @@
 			);
 			mainGroup = 1521D80D2D9C4D6200C4DFDF;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				152E82782DC43AF700FB787B /* XCLocalSwiftPackageReference "../Mail" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1521D8172D9C4D6200C4DFDF /* Products */;
 			projectDirPath = "";
@@ -324,6 +333,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Thunderbird/Thunderbird.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BUMSKVQ3D9;
@@ -351,7 +361,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
@@ -363,6 +373,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Thunderbird/Thunderbird.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BUMSKVQ3D9;
@@ -390,7 +401,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
@@ -412,7 +423,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Thunderbird.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Thunderbird";
 				XROS_DEPLOYMENT_TARGET = 2.4;
@@ -435,7 +446,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Thunderbird.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Thunderbird";
 				XROS_DEPLOYMENT_TARGET = 2.4;
@@ -473,6 +484,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		152E82782DC43AF700FB787B /* XCLocalSwiftPackageReference "../Mail" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../Mail;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		152E82792DC43AF700FB787B /* Account */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Account;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 1521D80E2D9C4D6200C4DFDF /* Project object */;
 }

--- a/Thunderbird/Thunderbird/WelcomeScreen.swift
+++ b/Thunderbird/Thunderbird/WelcomeScreen.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Account
 
 struct WelcomeScreen: View {
     @Environment(\.openURL) private var openURL


### PR DESCRIPTION
PR begins Thunderbird iOS's "account" journey by addressing secure secret storage.

I expect every app that handles passwords and tokens to store them securely -- encrypted. I expect apps that run on Apple platforms to use the provided [system keychain.](https://developer.apple.com/documentation/security/keychain-services)

All Thunderbird iOS secrets, starting with incoming/outgoing mail server passwords:

* Stored permanently in separate `thunderbird.net` realm ("secure space" in Apple parlance)
* Named with unique, human-readable labels: "user@example.com IMAP:ADP4RV" or "[username] [protocol]:[UUID]"

On macOS, Thunderbird passwords appear in Keychain Access like so:

![account-keychain](https://github.com/user-attachments/assets/2e98103a-bc39-47c8-b8de-bab36329ccd9)

-----

This PR also adds the first (local) Swift package, `Mail`, to the Xcode workspace. CI workflows required the following updates:

* Add package graph resolution step to analyze/test workflow
* Build all targets and packages with Swift 6.0, not 6.1 (temporary; for hosted CI runner compatibility)
* Extra file white-space linting (temporary; for hosted CI runner compatibility)

`Mail` contains a single new library, `Account`, including:

* Extend [`URLCredentialStorage`](https://developer.apple.com/documentation/foundation/urlcredentialstorage) to set/unset and read passwords from system keychain
* Model incoming and outgoing mail server connections to use secure password storage
* Add account tests to test plan

![account-keychain-tests](https://github.com/user-attachments/assets/979a4df6-cd58-478b-9b40-0ddfcbcde2db)

Close #25 