### PR TITLE
feat(account): OAuth token type, button bindings

### DIFF
--- a/Feature/Sources/Account/Authorization.swift
+++ b/Feature/Sources/Account/Authorization.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Authorization credential  for a given user name, either an OAuth token or basic password
 public enum Authorization: CustomStringConvertible, Equatable {
     case basic(user: String, password: String)
-    case oauth(user: String, token: String)
+    case oauth(user: String, token: Token)
     case none
 
     public var user: String {
@@ -26,7 +26,7 @@ public enum Authorization: CustomStringConvertible, Equatable {
     var password: String {
         switch self {
         case .basic(let user, let password): "\(user.components(separatedBy: " ")[0]):\(password)".data(using: .utf8)!.base64EncodedString()
-        case .oauth(_, let token): token
+        case .oauth(_, let token): token.description
         case .none: ""
         }
     }
@@ -40,7 +40,7 @@ public enum Authorization: CustomStringConvertible, Equatable {
         {
             self = .basic(user: user, password: components.last!)
         } else {
-            self = .oauth(user: user, token: password)
+            self = .oauth(user: user, token: .bearer(password))
         }
     }
 

--- a/Feature/Sources/Account/Token.swift
+++ b/Feature/Sources/Account/Token.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public enum Token: CustomStringConvertible, Equatable, ExpressibleByStringLiteral {
+    case bearer(String)
+
+    var value: String {
+        switch self {
+        case .bearer(let token): token
+        }
+    }
+
+    // MARK: CustomStringConvertible
+    public var description: String { value }
+
+    // MARK: ExpressibleByStringLiteral
+    public init(stringLiteral value: String) {
+        self = .bearer(value)
+    }
+}

--- a/Thunderbird/Thunderbird/Account/AuthorizationView.swift
+++ b/Thunderbird/Thunderbird/Account/AuthorizationView.swift
@@ -7,20 +7,25 @@ struct AuthorizationView: View {
     let username: String
     let authenticationType: AuthenticationType
 
-    init(_ authorization: Binding<Authorization>, for username: String, authenticationType: AuthenticationType = .oAuth2) {
+    init(_ authorization: Binding<Authorization>, error: Binding<Error?>, for username: String, authenticationType: AuthenticationType = .oAuth2) {
         self.username = username
         self.authenticationType = authenticationType
         _authorization = authorization
         switch authorization.wrappedValue {
-        case .basic(_, let password), .oauth(_, let password):
+        case .basic(_, let password):
             self.password = password
+        case .oauth(_, let token):
+            self.token = token
         case .none:
             break
         }
+        _error = error
     }
 
     @Binding private var authorization: Authorization
+    @Binding private var error: Error?
     @State private var password: String = ""
+    @State private var token: Token?
 
     // MARK: View
     var body: some View {
@@ -31,7 +36,14 @@ struct AuthorizationView: View {
                     authorization = .basic(user: username, password: password)
                 }
         case .oAuth2:
-            OAuthButton(username)
+            OAuthButton(username, token: $token, error: $error)
+                .onChange(of: token, initial: true) {
+                    if let token {
+                        authorization = .oauth(user: username, token: token)
+                    } else {
+                        authorization = .none
+                    }
+                }
         case .none:
             EmptyView()
         }
@@ -40,7 +52,8 @@ struct AuthorizationView: View {
 
 #Preview("Authorization View") {
     @Previewable @State var authorization: Authorization = .none
+    @Previewable @State var error: Error?
 
-    AuthorizationView($authorization, for: "example@thunderbird.net")
+    AuthorizationView($authorization, error: $error, for: "example@thunderbird.net")
         .padding()
 }

--- a/Thunderbird/Thunderbird/Account/EditServerView.swift
+++ b/Thunderbird/Thunderbird/Account/EditServerView.swift
@@ -8,6 +8,7 @@ struct EditServerView: View {
 
     @Binding private var server: Server
     @State private var password: String = ""
+    @State private var error: Error?
 
     // MARK: View
     var body: some View {
@@ -70,7 +71,12 @@ struct EditServerView: View {
 
                 }
             }
-            AuthorizationView($server.authorization, for: server.username, authenticationType: server.authenticationType)
+            AuthorizationView(
+                $server.authorization,
+                error: $error,
+                for: server.username,
+                authenticationType: server.authenticationType
+            )
         }
         .textFieldStyle(.roundedBorder)
         #if os(iOS)

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -1,3 +1,4 @@
+import Account
 import AuthenticationServices
 import Autoconfiguration
 import SwiftUI
@@ -5,13 +6,16 @@ import SwiftUI
 struct OAuthButton: View {
     let emailAddress: EmailAddress
 
-    init(_ emailAddress: EmailAddress = "") {
+    init(_ emailAddress: EmailAddress = "", token: Binding<Token?>, error: Binding<Error?>) {
         self.emailAddress = emailAddress
+        _token = token
+        _error = error
     }
 
+    @Binding private var token: Token?
+    @Binding private var error: Error?
     @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @State private var request: OAuth2.Request?
-    @State private var error: Error?
 
     private func authenticate() async {
         do {
@@ -21,7 +25,9 @@ struct OAuthButton: View {
                 using: request.authURL(hint: emailAddress),
                 callback: .customScheme("\(Bundle.main.schemes.first!)"),
                 additionalHeaderFields: [:])
-            print(url)
+
+            // TODO: Exchange auth code for bearer or access/refresh token; for now, succeed here and return fake bearer token...
+            token = .bearer("fake-1e911257e86b1f194daa-0-a89faae5c11f")
         } catch {
             self.error = error
         }
@@ -53,5 +59,8 @@ struct OAuthButton: View {
 }
 
 #Preview("OAuth Button") {
-    OAuthButton("example@thunderbird.net")
+    @Previewable @State var token: Token?
+    @Previewable @State var error: Error?
+
+    OAuthButton("example@thunderbird.net", token: $token, error: $error)
 }

--- a/Thunderbird/Thunderbird/AccountInformation.swift
+++ b/Thunderbird/Thunderbird/AccountInformation.swift
@@ -60,6 +60,7 @@ struct AccountInformation: View {
                 if account?.incomingServer?.authenticationType != nil {
                     AuthorizationView(
                         $loginServer.authorization,
+                        error: $error,
                         for: loginServer.username,
                         authenticationType: loginServer.authenticationType
                     ).onChange(of: loginServer.authorization) {

--- a/Thunderbird/Thunderbird/ManualServerSetup.swift
+++ b/Thunderbird/Thunderbird/ManualServerSetup.swift
@@ -36,6 +36,7 @@ struct ManualServerSetup: View {
     @State private var outSelectedSecurity: Bool
     @State private var manualConfig: Bool
     @State private var account: Account
+    @State private var error: Error?
 
     // MARK: View
     var body: some View {
@@ -54,7 +55,12 @@ struct ManualServerSetup: View {
                     .onChange(of: incomingServer.authenticationType, initial: true) {
 
                     }
-                    AuthorizationView($incomingServer.authorization, for: incomingServer.username, authenticationType: incomingServer.authenticationType)
+                    AuthorizationView(
+                        $incomingServer.authorization,
+                        error: $error,
+                        for: incomingServer.username,
+                        authenticationType: incomingServer.authenticationType
+                    )
 
                     Toggle("account_server_settings_security_label", isOn: $inSelectedSecurity)
                         .tint(.accent)
@@ -76,7 +82,12 @@ struct ManualServerSetup: View {
                     .onChange(of: incomingServer.authenticationType, initial: true) {
 
                     }
-                    AuthorizationView($incomingServer.authorization, for: incomingServer.username, authenticationType: incomingServer.authenticationType)
+                    AuthorizationView(
+                        $incomingServer.authorization,
+                        error: $error,
+                        for: incomingServer.username,
+                        authenticationType: incomingServer.authenticationType
+                    )
                     Toggle("account_server_settings_security_label", isOn: $inSelectedSecurity)
                         .tint(.accent)
                         .listRowSeparator(.hidden)
@@ -97,6 +108,7 @@ struct ManualServerSetup: View {
                     }
                     AuthorizationView(
                         $outgoingServer.authorization,
+                        error: $error,
                         for: outgoingServer.username,
                         authenticationType: outgoingServer.authenticationType
                     )


### PR DESCRIPTION
* Add OAuth `Token` type to `Account.Authorization`
* Add token and error bindings to `OAuthButton`

Note that `bearer` is the only token case today; access/refresh token case TBD. `OAuthButton` returns a fake bearer token on web flow success.