### PR TITLE
chore(ci): CodeQL use default xcode verison and only run cron

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -1,10 +1,6 @@
 name: Security - CodeQL
 
 on:
-  push:
-    branches: ["main", "codeql"]
-  pull_request:
-    branches: ["main"]
   schedule:
     - cron: "15 4 * * 4"
 
@@ -32,12 +28,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Xcode Select Version
-        if: matrix.language == 'swift'
-        uses: mobiledevops/xcode-select-version-action@a58204ef24b6e61857940e51c0e11b0368065b94 # v1.0.0
-        with:
-          xcode-select-version: '26.0'
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
@@ -52,7 +42,8 @@ jobs:
             -workspace Thunderbird.xcworkspace \
             -scheme Thunderbird \
             -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,name=iPhone 17"
+            -destination "platform=iOS Simulator,name=iPhone 17" \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1


### PR DESCRIPTION
Drops selection of the xcode version and run with the default.
This gets CodeQL for swift to run successfully again.

The workflow is now only run as a cron once weekly because the
swift compile takes a while.

Code signing is also skipped as it's not necessary.