### PR TITLE
Fix CI testplan hang

### DIFF
--- a/Thunderbird.xctestplan
+++ b/Thunderbird.xctestplan
@@ -20,6 +20,13 @@
       }
     },
     {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "ColorTests"
+          }
+        ]
+      },
       "target" : {
         "containerPath" : "container:..\/Bolt",
         "identifier" : "BoltUITests",


### PR DESCRIPTION
Testplan hangs in CI again, and the hang seems to always be one of the dynamic color resolution tests for `BoltUI`. What those tests have in common is that they use the SwiftUI `colorScheme` environment variable, so guessing GH virtualized macOS shenanigans...

CI testplan runs have to skip color tests for now.