### PR TITLE
chore(ci): Add cooldown of 7 days to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cool-down:
+      default-days: 7
     labels:
       - "type: dependency"
       - "type: github actions"
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cool-down:
+      default-days: 7
     labels:
       - "type: dependency"
       - "type: swift package"


### PR DESCRIPTION
This helps avoid supply chain attacks by not pulling in changes too quickly.