### PR TITLE
fix(UI): Gesture conflict on EmailCellView

### DIFF
--- a/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
@@ -110,6 +110,8 @@ struct EmailCellView: View {
 }
 
 #Preview("Email Cell") {
+    @Previewable @State var flags: FeatureFlags = FeatureFlags(distribution: .current)
+
     var tempEmail = TempEmail(
         from: [EmailAddress("sender1@test.com", label: "Sender1")],
         sender: [EmailAddress("sender1@test.com", label: "Sender1")],
@@ -366,6 +368,7 @@ struct EmailCellView: View {
         isThread: false,
         pinned: true
     )
-    EmailCellView(email: tempEmail)
+    
+    EmailCellView(email: tempEmail).environment(flags)
 
 }

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
@@ -37,76 +37,76 @@ struct EmailCellView: View {
     }
 
     var body: some View {
-        return NavigationLink(
-            destination: ReadEmailView(
-                email
-            )
-        ) {
-            VStack(alignment: .leading) {
-                HStack {
-                    if pinned {
-                        Image("icon.pin")
-                            .font(.system(size: 8))
-                    }
-                    Text(senderText)
-                        .lineLimit(1)
-                        .font(.headline)
-                        .fontWeight(unread ? .semibold : .regular)
-                    Spacer()
-                    Text(
-                        SmartDateFormatter()
-                            .dateFormatter(date: dateSent, isSmartDate: !flags.flagForKey(key: Flag.fullDate.rawValue))
-                    )
-                    .lineLimit(1)
-                    .font(.footnote)
-                    .truncationMode(.tail)
-                    .foregroundColor(.muted)
-
-                }.padding(.leading, pinned ? 0 : 20)
-                HStack {
-                    if newEmail {
-                        Image(systemName: "circle")
-                            .foregroundStyle(.accent)
-                            .font(.system(size: 8))
-                    } else if unread {
-                        Image(systemName: "circle.fill")
-                            .foregroundStyle(.accent)
-                            .font(.system(size: 8))
-                    }
-                    Text(headerText)
-                        .lineLimit(1)
-                        .font(.subheadline)
-                        .fontWeight(unread ? .semibold : .regular)
-                    Spacer()
-                    if hasAttachment {
-                        Image(systemName: "paperclip")
-                            .foregroundColor(.muted)
-                    }
-                    if isThread {
-                        Text("99+")
-                            .font(.caption2)
-                            .padding(.horizontal, 5)
-                            .foregroundColor(.muted)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 18)
-                                    .stroke(lineWidth: 1)
-                                    .foregroundColor(.muted)
-                            )
-
-                    }
-
+        VStack(alignment: .leading) {
+            HStack {
+                if pinned {
+                    Image("icon.pin")
+                        .font(.system(size: 8))
                 }
-                .padding(.leading, newEmail || unread ? 0 : 20)
-                Text(bodyText)
+
+                Text(senderText)
                     .lineLimit(1)
-                    .foregroundColor(.muted)
-                    .font(.footnote)
-                    .padding(.leading, 20)
+                    .font(.headline)
+                    .fontWeight(unread ? .semibold : .regular)
+
+                Spacer()
+
+                Text(
+                    SmartDateFormatter()
+                        .dateFormatter(date: dateSent, isSmartDate: !flags.flagForKey(key: Flag.fullDate.rawValue))
+                )
+                .lineLimit(1)
+                .font(.footnote)
+                .truncationMode(.tail)
+                .foregroundColor(.muted)
 
             }
-        }.navigationLinkIndicatorVisibility(.hidden)
-    }
+            .padding(.leading, pinned ? 0 : 20)
 
+            HStack {
+                if newEmail {
+                    Image(systemName: "circle")
+                        .foregroundStyle(.accent)
+                        .font(.system(size: 8))
+                } else if unread {
+                    Image(systemName: "circle.fill")
+                        .foregroundStyle(.accent)
+                        .font(.system(size: 8))
+                }
+
+                Text(headerText)
+                    .lineLimit(1)
+                    .font(.subheadline)
+                    .fontWeight(unread ? .semibold : .regular)
+
+                Spacer()
+
+                if hasAttachment {
+                    Image(systemName: "paperclip")
+                        .foregroundColor(.muted)
+                }
+
+                if isThread {
+                    Text("99+")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .foregroundColor(.muted)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18)
+                                .stroke(lineWidth: 1)
+                                .foregroundColor(.muted)
+                        )
+                }
+            }
+            .padding(.leading, newEmail || unread ? 0 : 20)
+
+            Text(bodyText)
+                .lineLimit(1)
+                .foregroundColor(.muted)
+                .font(.footnote)
+                .padding(.leading, 20)
+        }
+    }
 }
 
 #Preview("Email Cell") {
@@ -359,7 +359,6 @@ struct EmailCellView: View {
             mDBW50_itmnHCI" width=3D"1" height=3D"1" border=3D"0" alt=3D"" /></body>
 
             </html>
-
             """,
         dateSent: Date(),
         unread: false,
@@ -370,5 +369,4 @@ struct EmailCellView: View {
     )
     
     EmailCellView(email: tempEmail).environment(flags)
-
 }

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
@@ -367,6 +367,6 @@ struct EmailCellView: View {
         isThread: false,
         pinned: true
     )
-    
+
     EmailCellView(email: tempEmail).environment(flags)
 }

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -170,7 +170,9 @@ struct EmailListView: View {
 }
 
 #Preview("Email List") {
+    @Previewable @State var flags: FeatureFlags = FeatureFlags(distribution: .current)
     @Previewable @State var accounts: Accounts = Accounts()
-    EmailListView().environment(accounts)
-
+    EmailListView()
+        .environment(flags)
+        .environment(accounts)
 }

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -75,6 +75,7 @@ struct EmailListView: View {
                             } label: {
                                 EmailCellView(email: email)
                             }
+                            .contentShape(Rectangle())
                             .simultaneousGesture (
                                 LongPressGesture().onEnded { _ in
                                     withAnimation {

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -76,7 +76,7 @@ struct EmailListView: View {
                                 EmailCellView(email: email)
                             }
                             .contentShape(Rectangle())
-                            .simultaneousGesture (
+                            .simultaneousGesture(
                                 LongPressGesture().onEnded { _ in
                                     withAnimation {
                                         editMode = .active

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -40,6 +40,7 @@ struct EmailListView: View {
             selections.insert(tempEmail.uuid)
         }
     }
+
     //TODO: replace with backend unread state call
     func markAllRead() {
         for tempEmail in tempEmails {
@@ -69,13 +70,19 @@ struct EmailListView: View {
                 } else {
                     VStack {
                         List(tempEmails, id: \.uuid, selection: $selections) { email in
-                            EmailCellView(email: email)
-                                .listRowSeparator(.hidden)
-                                .onLongPressGesture {
+                            NavigationLink {
+                                ReadEmailView(email)
+                            } label: {
+                                EmailCellView(email: email)
+                            }
+                            .simultaneousGesture (
+                                LongPressGesture().onEnded { _ in
                                     withAnimation {
                                         editMode = .active
                                     }
                                 }
+                            )
+                            .listRowSeparator(.hidden)
                         }
                     }.environment(\.editMode, $editMode)
                         .listStyle(.plain)
@@ -165,7 +172,6 @@ struct EmailListView: View {
                 }
             }
         }
-
     }
 }
 


### PR DESCRIPTION
Issue: When interacting with an email cell in the primary list of emails in the application, only portions of the cell could be interacted with at a time. Long press only worked when interacting with "filled" elements (text, icons, etc.) and the tap to navigate to an email's detail view only worked when interacting with "unfilled" areas.

Fix: 
* The `NavigationLink` wrapper has been moved from the `EmailCellView` to the `EmailListView`. This is purely for formatting and keeping the navigation tied to the parent rather than the child.
* The `LongPressGesture` for switching to editing mode now has a `simultaneousGesture` wrapper, enabling the gestures to coexist without conflicting or getting messy with hit trackers. This will also allow us to use swipe actions on cells without issues in the future.
* The `EmailCellView` now has a static shape applied to it's background to allow interaction anywhere within the cell. 