### PR TITLE
chore(pr): Add PR template for git contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+> [!IMPORTANT]
+> Pull requests may take a few days to weeks to review. We’re a small team and prioritize contributions aligned with our [current roadmap](https://roadmaps.thunderbird.net/en-US/ios). 
+> You can help us by categorizing your pull request with labels. 
+> We appreciate you working with us and will get to reviewing your contribution as soon as we can!
+
+## Contribution Summary
+_Please provide a detailed outline changes to the project here._
+
+## Screenshots
+_Please include any screenshots of modified visuals within the project._
+
+## AI Contribution Disclosure
+- [ ] This contribution does not include any changes created or assisted by AI.
+- [ ] This contribution includes changes assisted by AI.
+- [ ] This contribution includes changes created by AI.
+
+_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._
+
+## Contribution Checklist
+- [ ] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
+- [ ] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
+- [ ] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
+- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
+- [ ] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).


### PR DESCRIPTION
Adds a PR template to the project for contributors to follow.

As we get additional documentation and guidelines for contribution we can include links to these documents in the template.