### PR TITLE
feat(account): common mailbox model and manager

### DIFF
--- a/Core/README.md
+++ b/Core/README.md
@@ -112,7 +112,7 @@ try await client.login(username: "name@example.com", password: "fAK3-PASs-w0rD")
 For the authenticated client, list mailboxes and select inbox:
 
 ```swift
-let mailboxes: [Mailbox] = try await client.list()  // List mailboxes
+let mailboxes: [Mailbox] = try await client.list().map { $0.0 }  // List mailboxes
 guard let inbox: Mailbox = mailboxes.filter({ $0.path.name.isInbox }).first else {
     throw IMAPError.unexpectedResponse("Inbox not found")
 }  // Find inbox in mailbox list

--- a/Core/Sources/Account/Account.swift
+++ b/Core/Sources/Account/Account.swift
@@ -99,3 +99,50 @@ extension Account {
         }
     }
 }
+
+extension Account {
+    var imapClient: IMAPClient {
+        get async throws {
+            if let client: IMAPClient = Self.clients[id] as? IMAPClient {
+                // IMAP Client already exists for account ID; reconnect and return
+                if !client.isConnected {
+                    try await client.connect()
+                    try await client.login()
+                }
+                return client
+            } else {
+                // No client exists for account ID; make a new one, connect and return
+                guard let incomingServer else {
+                    throw IMAPError.serverProtocolMismatch
+                }
+                let client: IMAPClient = IMAPClient(try IMAP.Server(incomingServer))
+                try await client.connect()
+                try await client.login()
+                Self.clients[id] = client  // Donate to shared pool
+                return client
+            }
+        }
+    }
+
+    var jmapClient: JMAPClient {
+        get async throws {
+            if let client: JMAPClient = Self.clients[id] as? JMAPClient, client.session != nil {
+                // JMAP Client already exists for account ID; return
+                return client
+            } else {
+                // No client exists for account ID; start a new session and return
+                guard let server: Server = servers.first else {
+                    throw JMAPError.serverProtocolMismatch
+                }
+                let client: JMAPClient = try await .session(try JMAP.Server(server))
+                guard client.session != nil else {
+                    throw JMAPError.sessionNotFound
+                }
+                return client
+            }
+        }
+    }
+
+    // Share existing IMAP and JMAP clients associated with account
+    nonisolated(unsafe) private static var clients: [UUID: Any] = [:]
+}

--- a/Core/Sources/Account/AccountManager.swift
+++ b/Core/Sources/Account/AccountManager.swift
@@ -4,7 +4,7 @@ public typealias Accounts = AccountManager
 
 /// Globally manage shared, persistent accounts from the SwiftUI environment.
 @Observable
-public class AccountManager {
+public final class AccountManager {
     public private(set) var allAccounts: [Account] = []
     public var error: AccountError?
 

--- a/Core/Sources/Account/AuthenticationType.swift
+++ b/Core/Sources/Account/AuthenticationType.swift
@@ -1,6 +1,6 @@
 import Autoconfiguration
 
-public enum AuthenticationType: String, Codable, CaseIterable, CustomStringConvertible, Identifiable {
+public enum AuthenticationType: String, Codable, CaseIterable, CustomStringConvertible, Identifiable, Sendable {
     case password
     case oAuth2 = "OAuth2"
     case none

--- a/Core/Sources/Account/Mailbox.swift
+++ b/Core/Sources/Account/Mailbox.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public struct Mailbox: CustomStringConvertible, Hashable, Identifiable, Sendable {
+    public typealias Role = JMAP.Mailbox.Role
+
+    public let role: Role?
+    public let name: String
+    public let isSubscribed: Bool
+    public let unreadEmails: Int?
+    public let totalEmails: Int?
+
+    public init(
+        _ name: String,
+        role: Role? = nil,
+        isSubscribed: Bool = false,
+        unreadEmails: Int? = nil,
+        totalEmails: Int? = nil,
+        id: String = UUID().uuidString(1)
+    ) {
+        self.role = role
+        self.name = name
+        self.isSubscribed = isSubscribed
+        self.unreadEmails = unreadEmails
+        self.totalEmails = totalEmails
+        self.id = id
+    }
+
+    // MARK: CustomStringConvertible
+    public var description: String { name }
+
+    // MARK: Identifiable
+    public let id: String
+}
+
+extension Mailbox {
+    init(_ mailbox: (IMAP.Mailbox, IMAP.Mailbox.Status?)) {
+        self.init(
+            mailbox.0.path.name.description,
+            role: mailbox.0.path.name == .inbox ? .inbox : nil,
+            isSubscribed: !mailbox.0.attributes.filter({ $0 == .subscribed }).isEmpty,
+            unreadEmails: mailbox.1?.unseenCount,
+            totalEmails: mailbox.1?.messageCount
+        )
+    }
+
+    init(_ mailbox: JMAP.Mailbox) {
+        self.init(
+            mailbox.name,
+            role: mailbox.role,
+            isSubscribed: mailbox.isSubscribed,
+            unreadEmails: mailbox.unreadEmails,
+            totalEmails: mailbox.totalEmails,
+            id: mailbox.id
+        )
+    }
+}

--- a/Core/Sources/Account/MailboxManager.swift
+++ b/Core/Sources/Account/MailboxManager.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@Observable
+public final class MailboxManager {
+    public let account: Account
+    public private(set) var mailboxes: [Mailbox] = []
+    public var error: AccountError?
+
+    public init(account: Account) {
+        self.account = account
+    }
+
+    public func mailbox(for id: String) -> Mailbox? {
+        mailboxes.filter({ $0.id == id }).first
+    }
+
+    public func refreshMailboxes() async {
+        do {
+            switch account.emailProtocol {
+            case .imap:
+                let client: IMAPClient = try await account.imapClient
+                let mailboxes: [(IMAP.Mailbox, IMAP.Mailbox.Status?)] = try await client.list()
+                self.mailboxes = mailboxes.map { Mailbox($0) }
+            case .jmap:
+                let client: JMAPClient = try await account.jmapClient
+                let mailboxes: [JMAP.Mailbox] = try await client.mailboxes()
+                self.mailboxes = mailboxes.map { Mailbox($0) }
+            }
+        } catch {
+            self.error = AccountError(error)
+        }
+    }
+}

--- a/Core/Sources/Account/Server.swift
+++ b/Core/Sources/Account/Server.swift
@@ -7,7 +7,7 @@ import MIME
 import SMTP
 
 /// All supported server types enumerated.
-public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible, Identifiable {
+public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertible, Identifiable, Sendable {
     case imap = "IMAP"
     case jmap = "JMAP"
     case smtp = "SMTP"
@@ -20,7 +20,7 @@ public enum ServerProtocol: String, Codable, CaseIterable, CustomStringConvertib
 }
 
 /// General purpose server model for any supported `ServerProtocol`. Stores authorization credentials locally in the [Apple keychain.](https://developer.apple.com/documentation/security/storing-keys-in-the-keychain)
-public struct Server: Codable, Equatable, Hashable, Identifiable {
+public struct Server: Codable, Equatable, Hashable, Identifiable, Sendable {
     public typealias ConnectionSecurity = IMAP.ConnectionSecurity
 
     public var serverProtocol: ServerProtocol

--- a/Core/Sources/Account/TestResult.swift
+++ b/Core/Sources/Account/TestResult.swift
@@ -1,65 +1,5 @@
 import Foundation
 
-extension Account {
-    /// Run basic validations for both IMAP/SMTP and JMAP `Account` configurations.
-    ///
-    /// Sleep duration clamps stream to a minimum delay between posted test results, useful for buffering UI updates.
-    @MainActor
-    public func test(sleep duration: Duration = .milliseconds(20)) -> AsyncStream<TestResult> {
-        let account: Self = self
-        return AsyncStream { continuation in
-            Task {
-                switch account.emailProtocol {
-                case .imap:
-                    var description: String = "IMAP CONNECT"
-                    do {
-                        guard let incomingServer: Server = account.incomingServer else {
-                            throw IMAPError.serverProtocolMismatch
-                        }
-                        let client: IMAPClient = IMAPClient(try IMAP.Server(incomingServer))
-                        try await client.connect()
-                        continuation.yield(.success(description))
-                        description = "IMAP AUTHENTICATE"
-                        try await client.login()
-                        continuation.yield(.success(description))
-                        for capability in client.capabilities {
-                            try await Task.sleep(for: duration)  // Buffer yield, just for drama
-                            continuation.yield(.success("IMAP \(capability)"))
-                        }
-                        try await client.logout()
-                        description = "SMTP SEND"
-                        guard let outgoingServer: Server = account.outgoingServer else {
-                            throw SMTPError.serverProtocolMismatch
-                        }
-                        let _: SMTPClient = SMTPClient(try SMTP.Server(outgoingServer))
-                        continuation.yield(.success(description))
-                    } catch {
-                        continuation.yield(.failure(description, error: error))
-                    }
-                case .jmap:
-                    do {
-                        guard let server: Server = account.servers.first else {
-                            throw JMAPError.serverProtocolMismatch
-                        }
-                        let client: JMAPClient = try await .session(try JMAP.Server(server))
-                        guard let session: Session = client.session else {
-                            throw JMAPError.sessionNotFound
-                        }
-                        continuation.yield(.success("JMAP SESSION"))
-                        for capability in session.capabilities.sorted(by: { $0.0.rawValue < $1.0.rawValue }) {
-                            try await Task.sleep(for: duration)  // Buffer yield, just for drama
-                            continuation.yield(.success("JMAP \(capability.key.description.uppercased())"))
-                        }
-                    } catch {
-                        continuation.yield(.failure("JMAP SESSION", error: error))
-                    }
-                }
-                continuation.finish()
-            }
-        }
-    }
-}
-
 public enum TestResult: CustomStringConvertible, Identifiable, Sendable {
     case failure(String, error: Error)
     case success(String)
@@ -85,6 +25,64 @@ public enum TestResult: CustomStringConvertible, Identifiable, Sendable {
         switch self {
         case .failure(let string, _): "\(string):x"
         case .success(let string): string
+        }
+    }
+}
+
+extension Account {
+    /// Run basic validations for both IMAP/SMTP and JMAP `Account` configurations.
+    @MainActor
+    public func test(sleep duration: Duration = .milliseconds(100)) -> AsyncStream<TestResult> {
+        let account: Self = self
+        return AsyncStream { continuation in
+            Task {
+                switch account.emailProtocol {
+                case .imap:
+                    var description: String = "IMAP CONNECT"
+                    do {
+                        guard let incomingServer: Server = account.incomingServer else {
+                            throw IMAPError.serverProtocolMismatch
+                        }
+                        let client: IMAPClient = IMAPClient(try IMAP.Server(incomingServer))
+                        try await client.connect()
+                        continuation.yield(.success(description))
+                        description = "IMAP AUTHENTICATE"
+                        try await client.login()
+                        continuation.yield(.success(description))
+                        for capability in client.capabilities {
+                            try await Task.sleep(for: duration)  // Just for drama
+                            continuation.yield(.success("IMAP \(capability)"))
+                        }
+                        try await client.logout()
+                        description = "SMTP SEND"
+                        guard let outgoingServer: Server = account.outgoingServer else {
+                            throw SMTPError.serverProtocolMismatch
+                        }
+                        let _: SMTPClient = SMTPClient(try SMTP.Server(outgoingServer))
+                        continuation.yield(.success(description))
+                    } catch {
+                        continuation.yield(.failure(description, error: error))
+                    }
+                case .jmap:
+                    do {
+                        guard let server: Server = account.servers.first else {
+                            throw JMAPError.serverProtocolMismatch
+                        }
+                        let client: JMAPClient = try await .session(try JMAP.Server(server))
+                        guard let session: Session = client.session else {
+                            throw JMAPError.sessionNotFound
+                        }
+                        continuation.yield(.success("JMAP SESSION"))
+                        for capability in session.capabilities.sorted(by: { $0.0.rawValue < $1.0.rawValue }) {
+                            try await Task.sleep(for: duration)  // Just for drama
+                            continuation.yield(.success("JMAP \(capability.key.description.uppercased())"))
+                        }
+                    } catch {
+                        continuation.yield(.failure("JMAP SESSION", error: error))
+                    }
+                }
+                continuation.finish()
+            }
         }
     }
 }

--- a/Core/Sources/IMAP/IMAPClient.swift
+++ b/Core/Sources/IMAP/IMAPClient.swift
@@ -109,7 +109,7 @@ public class IMAPClient {
     }
 
     /// List all mailboxes on logged-in IMAP ``Server``.
-    public func list(wildcard: Character = .wildcard) async throws -> [Mailbox] {
+    public func list(wildcard: Character = .wildcard) async throws -> [(Mailbox, Mailbox.Status?)] {
         logger?.info("Listing mailboxes…")
         return try await execute(command: ListCommand(wildcard: wildcard))
     }

--- a/Core/Sources/IMAP/ListCommand.swift
+++ b/Core/Sources/IMAP/ListCommand.swift
@@ -6,13 +6,23 @@ struct ListCommand: IMAPCommand {
     let options: [ReturnOption]
     let wildcard: Character
 
-    init(options: [ReturnOption] = [], wildcard: Character) {
+    init(
+        options: [ReturnOption] = [
+            .subscribed,
+            .statusOption([
+                .messageCount,
+                .recentCount,
+                .unseenCount
+            ])
+        ],
+        wildcard: Character
+    ) {
         self.options = options
         self.wildcard = wildcard
     }
 
     // MARK: IMAPCommand
-    typealias Result = [MailboxInfo]
+    typealias Result = [(MailboxInfo, MailboxStatus?)]
     typealias Handler = ListHandler
 
     var name: String { "list" }
@@ -27,9 +37,10 @@ class ListHandler: IMAPCommandHandler, @unchecked Sendable {
     // MARK: IMAPCommandHandler
     typealias InboundIn = Response
     typealias InboundOut = Response
-    typealias Result = [MailboxInfo]
+    typealias Result = [(MailboxInfo, MailboxStatus?)]
 
-    var mailboxes: Result = []
+    var mailboxes: [MailboxInfo] = []
+    var status: [MailboxName: MailboxStatus] = [:]
     var clientBug: String? = nil
     let promise: EventLoopPromise<Result>
     let tag: String
@@ -48,12 +59,14 @@ class ListHandler: IMAPCommandHandler, @unchecked Sendable {
             case .bad(let text), .no(let text):
                 promise.fail(IMAPError.commandFailed(text.text))
             case .ok:
-                promise.succeed(mailboxes)
+                promise.succeed(mailboxes.map { ($0, status[$0.path.name]) })
             }
         case .untagged(let payload):
             switch payload {
             case .mailboxData(.list(let mailbox)):
                 mailboxes.append(mailbox)
+            case .mailboxData(.status(let name, let status)):
+                self.status[name] = status
             default:
                 break
             }

--- a/Core/Sources/IMAP/Mailbox.swift
+++ b/Core/Sources/IMAP/Mailbox.swift
@@ -11,7 +11,7 @@ extension Mailbox {
 }
 
 extension MailboxName: @retroactive CustomStringConvertible {
-    init(_ string: String) {
+    public init(_ string: String) {
         self.init(ByteBuffer(string: string))
     }
 

--- a/Core/Tests/AccountTests/AccountTests.swift
+++ b/Core/Tests/AccountTests/AccountTests.swift
@@ -43,17 +43,46 @@ extension AccountTests {
     }
 }
 
-private extension Server {
-    static var jmap: Self {
-        Self(
-            .jmap,
-            connectionSecurity: .none,
-            authenticationType: .none,
-            username: "user",
-            hostname: "jmap.example.com"
-        )
+extension AccountTests {
+    @Test func imapClient() async throws {
+        await #expect(throws: IMAPError.self) {
+            let _ = try await Account.imap.imapClient
+        }
     }
 
+    @Test func jmapClient() async throws {
+        await #expect(throws: URLError.self) {
+            let _ = try await Account.jmap.jmapClient
+        }
+    }
+}
+
+private extension Account {
+    static var imap: Self {
+        Self(
+            name: "",
+            identities: [
+                "example@thunderbird.net"
+            ],
+            servers: [
+                .gmail,
+                Server(.smtp)
+            ])
+    }
+
+    static var jmap: Self {
+        Self(
+            name: "",
+            identities: [
+                "example@fastmail.com"
+            ],
+            servers: [
+                .fastmail
+            ])
+    }
+}
+
+private extension Server {
     static var imap: Self {
         Self(
             .imap,
@@ -61,6 +90,16 @@ private extension Server {
             authenticationType: .none,
             username: "user",
             hostname: "imap.example.com"
+        )
+    }
+
+    static var jmap: Self {
+        Self(
+            .jmap,
+            connectionSecurity: .none,
+            authenticationType: .none,
+            username: "user",
+            hostname: "jmap.example.com"
         )
     }
 

--- a/Core/Tests/AccountTests/Server.swift
+++ b/Core/Tests/AccountTests/Server.swift
@@ -1,0 +1,29 @@
+import Account
+import Testing
+
+extension Server: CaseIterable {
+
+    // MARK: Fastmail
+    static var fastmail: Self {
+        Self(
+            .jmap,
+            connectionSecurity: .tls,
+            username: "example@fastmail.com",
+            hostname: "api.fastmail.com"
+        )
+    }
+
+    // MARK: Gmail
+    static var gmail: Self {
+        Self(
+            .imap,
+            connectionSecurity: .tls,
+            authenticationType: .password,
+            username: "example@thunderbird.net",
+            hostname: "imap.gmail.com"
+        )
+    }
+
+    // MARK: CaseIterable
+    public static let allCases: [Self] = [.fastmail, .gmail]
+}

--- a/Core/Tests/IMAPTests/IMAPClientTests.swift
+++ b/Core/Tests/IMAPTests/IMAPClientTests.swift
@@ -9,8 +9,8 @@ struct IMAPClientTests {
         try await client.connect()
         try await client.login()  // Use credentials in canned `Server`
 
-        let mailboxes: [Mailbox] = try await client.list()  // List mailboxes
-        guard let inbox: Mailbox = mailboxes.filter({ $0.path.name.isInbox }).first else {
+        let mailboxes: [(Mailbox, Mailbox.Status?)] = try await client.list()  // List mailboxes
+        guard let inbox: Mailbox = mailboxes.filter({ $0.0.path.name.isInbox }).first?.0 else {
             throw IMAPError.unexpectedResponse("Inbox not found")
         }  // Find inbox in mailbox list
         try await client.select(mailbox: inbox)  // Select inbox

--- a/Thunderbird.xctestplan
+++ b/Thunderbird.xctestplan
@@ -41,6 +41,17 @@
       }
     },
     {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "AccountTests",
+            "testFunctions" : [
+              "imapClient()",
+              "jmapClient()"
+            ]
+          }
+        ]
+      },
       "target" : {
         "containerPath" : "container:..\/Core",
         "identifier" : "AccountTests",


### PR DESCRIPTION
PR begins a common mailbox implementation for core `Account` library by adding:

* `Mailbox` model that unifies IMAP and JMAP folder/mailbox concepts
* Observable `MailboxManager` that loads mailboxes for a given `Account` 

<video src="https://github.com/user-attachments/assets/b03e89e3-8ce8-4149-9bff-8039766952fb"></video>

A couple of changes support adding common mailboxes:

* `IMAPClient.list` extended to return mailbox subscription (`lsub`) and status
* `Account` internally extended with a reusable IMAP or JMAP client

Close #299 