### PR TITLE
Add MPL2 license to headers

### DIFF
--- a/Bolt/Sources/BoltUI/Color.swift
+++ b/Bolt/Sources/BoltUI/Color.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 #if canImport(AppKit)
 import AppKit

--- a/Bolt/Sources/BoltUI/Font.swift
+++ b/Bolt/Sources/BoltUI/Font.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 extension Font {

--- a/Bolt/Sources/BoltUI/Foundation.swift
+++ b/Bolt/Sources/BoltUI/Foundation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import CoreGraphics
 

--- a/Bolt/Sources/BoltUI/TextStyleViewModifier.swift
+++ b/Bolt/Sources/BoltUI/TextStyleViewModifier.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 extension View {

--- a/Bolt/Tests/BoltUITests/ColorTests.swift
+++ b/Bolt/Tests/BoltUITests/ColorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 import Testing
 @testable import BoltUI

--- a/Bolt/Tests/BoltUITests/FoundationTests.swift
+++ b/Bolt/Tests/BoltUITests/FoundationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import Testing
 @testable import BoltUI

--- a/Bolt/Tests/EditorTests/Tests.swift
+++ b/Bolt/Tests/EditorTests/Tests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Testing
 @testable import Editor
 

--- a/Core/Sources/Account/Account.swift
+++ b/Core/Sources/Account/Account.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @_exported import Autoconfiguration
 @_exported import EmailAddress
 @_exported import IMAP

--- a/Core/Sources/Account/AccountError.swift
+++ b/Core/Sources/Account/AccountError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 public enum AccountError: CustomStringConvertible, Error, Equatable {
     case autoconfig(Error)
     case fileManager(Error)

--- a/Core/Sources/Account/AccountManager.swift
+++ b/Core/Sources/Account/AccountManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public typealias Accounts = AccountManager

--- a/Core/Sources/Account/AuthenticationType.swift
+++ b/Core/Sources/Account/AuthenticationType.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 
 public enum AuthenticationType: String, Codable, CaseIterable, CustomStringConvertible, Identifiable {

--- a/Core/Sources/Account/Authorization.swift
+++ b/Core/Sources/Account/Authorization.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Authorization credential  for a given user name, either an OAuth token or basic password

--- a/Core/Sources/Account/DeletePolicy.swift
+++ b/Core/Sources/Account/DeletePolicy.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public enum DeletePolicy: Codable, CustomStringConvertible, Equatable, Hashable, RawRepresentable {

--- a/Core/Sources/Account/FileManager.swift
+++ b/Core/Sources/Account/FileManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 // Read and write accounts to JSON file on disk; stopgap for account persistence

--- a/Core/Sources/Account/Server.swift
+++ b/Core/Sources/Account/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 import EmailAddress
 import Foundation

--- a/Core/Sources/Account/TestResult.swift
+++ b/Core/Sources/Account/TestResult.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension Account {

--- a/Core/Sources/Account/Token.swift
+++ b/Core/Sources/Account/Token.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public enum Token: CustomStringConvertible, Equatable, ExpressibleByStringLiteral {

--- a/Core/Sources/Account/URLCredentialStorage.swift
+++ b/Core/Sources/Account/URLCredentialStorage.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLCredentialStorage {

--- a/Core/Sources/Account/URLProtectionSpace.swift
+++ b/Core/Sources/Account/URLProtectionSpace.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLProtectionSpace {

--- a/Core/Sources/Autoconfiguration/Bundle.swift
+++ b/Core/Sources/Autoconfiguration/Bundle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension Bundle {

--- a/Core/Sources/Autoconfiguration/ClientConfig.swift
+++ b/Core/Sources/Autoconfiguration/ClientConfig.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 public struct ClientConfig: Decodable, Equatable {
     public let emailProvider: EmailProvider?
     public let oAuth2: OAuth2?

--- a/Core/Sources/Autoconfiguration/DNSResolver.swift
+++ b/Core/Sources/Autoconfiguration/DNSResolver.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @_exported import AsyncDNSResolver
 import Foundation
 

--- a/Core/Sources/Autoconfiguration/DomainParser.swift
+++ b/Core/Sources/Autoconfiguration/DomainParser.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 struct DomainParser {

--- a/Core/Sources/Autoconfiguration/EmailProvider.swift
+++ b/Core/Sources/Autoconfiguration/EmailProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public struct EmailProvider: Decodable {

--- a/Core/Sources/Autoconfiguration/OAuth2.swift
+++ b/Core/Sources/Autoconfiguration/OAuth2.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public struct OAuth2: Decodable {

--- a/Core/Sources/Autoconfiguration/SRVRecord.swift
+++ b/Core/Sources/Autoconfiguration/SRVRecord.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import AsyncDNSResolver
 import Foundation
 

--- a/Core/Sources/Autoconfiguration/SRVResolver.swift
+++ b/Core/Sources/Autoconfiguration/SRVResolver.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import dnssd
 

--- a/Core/Sources/Autoconfiguration/Service.swift
+++ b/Core/Sources/Autoconfiguration/Service.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Standard email services/protocols to query DNS SRV records for
 public enum Service: String, CaseIterable, CustomStringConvertible {
     case autodiscover, imap, imaps, jmap, smtp, submission

--- a/Core/Sources/Autoconfiguration/Source.swift
+++ b/Core/Sources/Autoconfiguration/Source.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Autoconfig locations to query, in order of trust: email provider subdomain or well-known, then ISPDB
 public enum Source: CaseIterable, CustomStringConvertible {
     case provider, wellKnown, ispDB  // Order of trust

--- a/Core/Sources/Autoconfiguration/String.swift
+++ b/Core/Sources/Autoconfiguration/String.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension String {

--- a/Core/Sources/Autoconfiguration/SuffixListParser.swift
+++ b/Core/Sources/Autoconfiguration/SuffixListParser.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 // Parse the Public Suffix List: https://publicsuffix.org

--- a/Core/Sources/Autoconfiguration/URL.swift
+++ b/Core/Sources/Autoconfiguration/URL.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URL {

--- a/Core/Sources/Autoconfiguration/URLRequest.swift
+++ b/Core/Sources/Autoconfiguration/URLRequest.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLRequest {

--- a/Core/Sources/Autoconfiguration/URLSession.swift
+++ b/Core/Sources/Autoconfiguration/URLSession.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLSession {

--- a/Core/Sources/Autoconfiguration/WebMail.swift
+++ b/Core/Sources/Autoconfiguration/WebMail.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public struct WebMail: Decodable {

--- a/Core/Sources/Autoconfiguration/XMLToJSONParser.swift
+++ b/Core/Sources/Autoconfiguration/XMLToJSONParser.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 // Translate client config XML into JSON

--- a/Core/Sources/AutoconfigurationCLI/Autoconfig.swift
+++ b/Core/Sources/AutoconfigurationCLI/Autoconfig.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import ArgumentParser
 import Autoconfiguration
 import Foundation

--- a/Core/Sources/AutoconfigurationCLI/Bundle.swift
+++ b/Core/Sources/AutoconfigurationCLI/Bundle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 #if canImport(Cocoa)
 import Cocoa
 #endif

--- a/Core/Sources/AutoconfigurationCLI/ClientConfig.swift
+++ b/Core/Sources/AutoconfigurationCLI/ClientConfig.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 #if canImport(Cocoa)
 import Cocoa

--- a/Core/Sources/AutoconfigurationCLI/FileManager.swift
+++ b/Core/Sources/AutoconfigurationCLI/FileManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 import Foundation
 

--- a/Core/Sources/AutoconfigurationCLI/Server.swift
+++ b/Core/Sources/AutoconfigurationCLI/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 
 extension [EmailProvider.Server.Authentication] {

--- a/Core/Sources/AutoconfigurationCLI/URLError.swift
+++ b/Core/Sources/AutoconfigurationCLI/URLError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLError: @retroactive CustomStringConvertible {

--- a/Core/Sources/Core/Account.swift
+++ b/Core/Sources/Core/Account.swift
@@ -1,1 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @_exported import Account

--- a/Core/Sources/EmailAddress/EmailAddress.swift
+++ b/Core/Sources/EmailAddress/EmailAddress.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public protocol EmailAddressProtocol: Sendable {

--- a/Core/Sources/EmailAddress/String.swift
+++ b/Core/Sources/EmailAddress/String.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 extension String {
     public var isEmailAddress: Bool { EmailAddress(self).isEmailAddress }
 

--- a/Core/Sources/IMAP/Capability.swift
+++ b/Core/Sources/IMAP/Capability.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAPCore
 

--- a/Core/Sources/IMAP/CapabilityCommand.swift
+++ b/Core/Sources/IMAP/CapabilityCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/ConnectionSecurity.swift
+++ b/Core/Sources/IMAP/ConnectionSecurity.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 public enum ConnectionSecurity: String, Codable, CaseIterable, CustomStringConvertible, Identifiable, Sendable {
     case startTLS = "STARTTLS"
     case tls = "SSL/TLS"

--- a/Core/Sources/IMAP/CopyCommand.swift
+++ b/Core/Sources/IMAP/CopyCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/CreateCommand.swift
+++ b/Core/Sources/IMAP/CreateCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/DeleteCommand.swift
+++ b/Core/Sources/IMAP/DeleteCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/EmailAddress.swift
+++ b/Core/Sources/IMAP/EmailAddress.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import MIME
 import NIOIMAPCore

--- a/Core/Sources/IMAP/Envelope.swift
+++ b/Core/Sources/IMAP/Envelope.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import Foundation
 import MIME

--- a/Core/Sources/IMAP/ExamineCommand.swift
+++ b/Core/Sources/IMAP/ExamineCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOIMAP
 
 // Select current working mailbox in read-only mode

--- a/Core/Sources/IMAP/FetchAttribute.swift
+++ b/Core/Sources/IMAP/FetchAttribute.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOIMAPCore
 
 public typealias FetchAttribute = NIOIMAPCore.FetchAttribute

--- a/Core/Sources/IMAP/FetchCommand.swift
+++ b/Core/Sources/IMAP/FetchCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import NIOCore
 import NIOIMAPCore

--- a/Core/Sources/IMAP/Flag.swift
+++ b/Core/Sources/IMAP/Flag.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOIMAPCore
 
 public typealias Flag = NIOIMAPCore.Flag

--- a/Core/Sources/IMAP/GmailLabel.swift
+++ b/Core/Sources/IMAP/GmailLabel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIOIMAPCore

--- a/Core/Sources/IMAP/IMAPClient.swift
+++ b/Core/Sources/IMAP/IMAPClient.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIO

--- a/Core/Sources/IMAP/IMAPCommand.swift
+++ b/Core/Sources/IMAP/IMAPCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIOCore

--- a/Core/Sources/IMAP/IMAPError.swift
+++ b/Core/Sources/IMAP/IMAPError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import MIME
 import NIOIMAPCore
 

--- a/Core/Sources/IMAP/IdleEvent.swift
+++ b/Core/Sources/IMAP/IdleEvent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Updates to selected ``Mailbox`` during ``IMAPClient`` idle
 public enum IdleEvent: Sendable {
 

--- a/Core/Sources/IMAP/IdleHandler.swift
+++ b/Core/Sources/IMAP/IdleHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/InternetMessageDate.swift
+++ b/Core/Sources/IMAP/InternetMessageDate.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIOIMAPCore

--- a/Core/Sources/IMAP/ListCommand.swift
+++ b/Core/Sources/IMAP/ListCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/LoggingHandler.swift
+++ b/Core/Sources/IMAP/LoggingHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import OSLog
 

--- a/Core/Sources/IMAP/LoginCommand.swift
+++ b/Core/Sources/IMAP/LoginCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/Mailbox.swift
+++ b/Core/Sources/IMAP/Mailbox.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import NIOCore
 import NIOIMAPCore

--- a/Core/Sources/IMAP/Message.swift
+++ b/Core/Sources/IMAP/Message.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIOIMAPCore

--- a/Core/Sources/IMAP/MoveCommand.swift
+++ b/Core/Sources/IMAP/MoveCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/Namespace.swift
+++ b/Core/Sources/IMAP/Namespace.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Merged  `NIOIMAPCore.NamespaceResponse` and `NamespaceDescription` model
 public struct Namespace: Hashable, Sendable {
     public enum Scope: String, CaseIterable, CustomStringConvertible, Sendable {

--- a/Core/Sources/IMAP/NamespaceCommand.swift
+++ b/Core/Sources/IMAP/NamespaceCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/NoopCommand.swift
+++ b/Core/Sources/IMAP/NoopCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import NIOCore
 import NIOIMAP

--- a/Core/Sources/IMAP/RenameCommand.swift
+++ b/Core/Sources/IMAP/RenameCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/SelectCommand.swift
+++ b/Core/Sources/IMAP/SelectCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/SequenceNumber.swift
+++ b/Core/Sources/IMAP/SequenceNumber.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOIMAPCore
 
 public typealias SequenceNumber = NIOIMAPCore.SequenceNumber

--- a/Core/Sources/IMAP/Server.swift
+++ b/Core/Sources/IMAP/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// ``IMAPClient`` connects to `Server`.
 public struct Server: CustomStringConvertible, Equatable, Sendable {
     public let connectionSecurity: ConnectionSecurity

--- a/Core/Sources/IMAP/ServerMessageDateFormatter.swift
+++ b/Core/Sources/IMAP/ServerMessageDateFormatter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 import NIOIMAPCore

--- a/Core/Sources/IMAP/StatusCommand.swift
+++ b/Core/Sources/IMAP/StatusCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/StoreCommand.swift
+++ b/Core/Sources/IMAP/StoreCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/SubscribeCommand.swift
+++ b/Core/Sources/IMAP/SubscribeCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/UID.swift
+++ b/Core/Sources/IMAP/UID.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOIMAPCore
 
 public typealias UID = NIOIMAPCore.UID

--- a/Core/Sources/IMAP/UIDCopyCommand.swift
+++ b/Core/Sources/IMAP/UIDCopyCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/UIDFetchCommand.swift
+++ b/Core/Sources/IMAP/UIDFetchCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/UIDMoveCommand.swift
+++ b/Core/Sources/IMAP/UIDMoveCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/UIDStoreCommand.swift
+++ b/Core/Sources/IMAP/UIDStoreCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/UnsubscribeCommand.swift
+++ b/Core/Sources/IMAP/UnsubscribeCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/IMAP/VoidCommand.swift
+++ b/Core/Sources/IMAP/VoidCommand.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import NIOIMAP
 

--- a/Core/Sources/JMAP/Account.swift
+++ b/Core/Sources/JMAP/Account.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Accounts are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)
 public struct Account: CustomStringConvertible, Decodable, Sendable {
     public let name: String

--- a/Core/Sources/JMAP/Authorization.swift
+++ b/Core/Sources/JMAP/Authorization.swift
@@ -1,3 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 import Foundation
 
 /// Configure ``Server`` with credentials or token for appropriate HTTP authentication scheme.

--- a/Core/Sources/JMAP/Capability.swift
+++ b/Core/Sources/JMAP/Capability.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Capabilities are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)
 public struct Capability: Decodable, Sendable {
     public enum Key: String, CaseIterable, Codable, CustomStringConvertible, Identifiable, Sendable {

--- a/Core/Sources/JMAP/Email.swift
+++ b/Core/Sources/JMAP/Email.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import UniformTypeIdentifiers
 

--- a/Core/Sources/JMAP/Filter.swift
+++ b/Core/Sources/JMAP/Filter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Filters narrow the returned responses when querying ``Email``, part of [JMAP core.](https://jmap.io/spec-core.html#query)

--- a/Core/Sources/JMAP/JMAPClient.swift
+++ b/Core/Sources/JMAP/JMAPClient.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import OSLog
 

--- a/Core/Sources/JMAP/JMAPError.swift
+++ b/Core/Sources/JMAP/JMAPError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// ``JMAPClient`` throws `JMAPError`.
 public enum JMAPError: Error, CustomStringConvertible, Equatable {
     case method(_ error: MethodError)

--- a/Core/Sources/JMAP/JSONDecoder.swift
+++ b/Core/Sources/JMAP/JSONDecoder.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension JSONDecoder {

--- a/Core/Sources/JMAP/Locale.swift
+++ b/Core/Sources/JMAP/Locale.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension Locale {

--- a/Core/Sources/JMAP/Mailbox.swift
+++ b/Core/Sources/JMAP/Mailbox.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Mailboxes are the primary mechanism for organizing ``Email`` within an ``Account``, part of [JMAP mail.](https://jmap.io/spec-mail.html#mailboxes)

--- a/Core/Sources/JMAP/Method.swift
+++ b/Core/Sources/JMAP/Method.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Standard request object, part of [JMAP core](https://jmap.io/spec-core.html#the-request-object)

--- a/Core/Sources/JMAP/MethodAction.swift
+++ b/Core/Sources/JMAP/MethodAction.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Possible `set` ``Method`` mutations, part of [JMAP corel](https://jmap.io/spec-core.html#set)
 public enum MethodAction: CustomStringConvertible {
     case create([String: Any])

--- a/Core/Sources/JMAP/MethodError.swift
+++ b/Core/Sources/JMAP/MethodError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Errors describing impossible or ineligible``Method`` operation, part of [JMAP core](https://jmap.io/spec-core.html#errors)

--- a/Core/Sources/JMAP/MethodResponse.swift
+++ b/Core/Sources/JMAP/MethodResponse.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Standard ``Method`` responses with generic response components modeled, part of [JMAP core](https://jmap.io/spec-core.html#the-response-object)

--- a/Core/Sources/JMAP/RequestError.swift
+++ b/Core/Sources/JMAP/RequestError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Request-level configuration errors, part of [JMAP core](https://jmap.io/spec-core.html#errors)
 public struct RequestError: Error, Decodable, CustomStringConvertible {
 

--- a/Core/Sources/JMAP/Server.swift
+++ b/Core/Sources/JMAP/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// ``JMAPClient`` requests ``Session`` from `Server`.
 public struct Server: CustomStringConvertible, Equatable, Sendable {
     public let authorization: Authorization?

--- a/Core/Sources/JMAP/Session.swift
+++ b/Core/Sources/JMAP/Session.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Sessions include details about the data and capabilities the server can provide to the client, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)

--- a/Core/Sources/JMAP/SetError.swift
+++ b/Core/Sources/JMAP/SetError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Errors encountered during a `set` ``Method`` operation, returned exclusively in ``MethodResponse``

--- a/Core/Sources/JMAP/Thread.swift
+++ b/Core/Sources/JMAP/Thread.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Threads group replies to an ``Email`` message , part of [JMAP mail.](https://jmap.io/spec-mail.html#threads)

--- a/Core/Sources/JMAP/URL.swift
+++ b/Core/Sources/JMAP/URL.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URL {

--- a/Core/Sources/JMAP/URLRequest.swift
+++ b/Core/Sources/JMAP/URLRequest.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLRequest {

--- a/Core/Sources/JMAP/URLSession.swift
+++ b/Core/Sources/JMAP/URLSession.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension URLSession {

--- a/Core/Sources/MIME/Body.swift
+++ b/Core/Sources/MIME/Body.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Multipart body element described in [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045#section-2.6)

--- a/Core/Sources/MIME/Boundary.swift
+++ b/Core/Sources/MIME/Boundary.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Multipart data boundary described in [RFC 2046](https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1)
 public struct Boundary: CustomStringConvertible, Equatable, RawRepresentable, Sendable {
     public static var bounds: ClosedRange<Int> { 1...70 }

--- a/Core/Sources/MIME/CharacterSet.swift
+++ b/Core/Sources/MIME/CharacterSet.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Character encoding described in [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045#section-2.2)
 public struct CharacterSet: CustomStringConvertible, Equatable, RawRepresentable, Sendable {
     public static var ascii: Self { try! Self("US-ASCII") }  // Default character encoding

--- a/Core/Sources/MIME/ContentDisposition.swift
+++ b/Core/Sources/MIME/ContentDisposition.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Multipart part content disposition and parameters described in [RFC 2183](https://www.rfc-editor.org/rfc/rfc2183)

--- a/Core/Sources/MIME/ContentTransferEncoding.swift
+++ b/Core/Sources/MIME/ContentTransferEncoding.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// Multipart email body must be ASCII in transfer. Parts encoded by this library use `base64` transfer encoding exclusively, but we expect to decode parts in any of the enumerated encodings, especially `quotedPrintable`.
 public enum ContentTransferEncoding: String, CaseIterable, CustomStringConvertible, RawRepresentable, Sendable {
     case ascii = "7bit"

--- a/Core/Sources/MIME/ContentType.swift
+++ b/Core/Sources/MIME/ContentType.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// [Media content types](https://www.iana.org/assignments/media-types/media-types.xhtml) with base types enumerated

--- a/Core/Sources/MIME/MIMEError.swift
+++ b/Core/Sources/MIME/MIMEError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 public enum MIMEError: Error, CustomStringConvertible, Equatable {

--- a/Core/Sources/MIME/Part.swift
+++ b/Core/Sources/MIME/Part.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// MIME part described in [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045#section-2.5)

--- a/Core/Sources/MIME/RFC822DateFormatter.swift
+++ b/Core/Sources/MIME/RFC822DateFormatter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// A formatter that converts between `Date` and  [RFC 822](https://www.rfc-editor.org/rfc/rfc822#section-5.1) `date-time` string representation

--- a/Core/Sources/MIME/String.swift
+++ b/Core/Sources/MIME/String.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension String {

--- a/Core/Sources/MIME/UUID.swift
+++ b/Core/Sources/MIME/UUID.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension UUID {

--- a/Core/Sources/SMTP/ByteHandler.swift
+++ b/Core/Sources/SMTP/ByteHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 
 // Proxy `MessageToByteHandler` as `@unchecked Sendable`

--- a/Core/Sources/SMTP/ConnectionSecurity.swift
+++ b/Core/Sources/SMTP/ConnectionSecurity.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 public enum ConnectionSecurity: String, Codable, CaseIterable, CustomStringConvertible, Identifiable, Sendable {
     case startTLS = "STARTTLS"
     case tls = "SSL/TLS"

--- a/Core/Sources/SMTP/Email.swift
+++ b/Core/Sources/SMTP/Email.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import Foundation
 import MIME

--- a/Core/Sources/SMTP/LoggingHandler.swift
+++ b/Core/Sources/SMTP/LoggingHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 import OSLog
 

--- a/Core/Sources/SMTP/MessageHandler.swift
+++ b/Core/Sources/SMTP/MessageHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 
 // Proxy `ByteToMessageHandler` as `@unchecked Sendable`

--- a/Core/Sources/SMTP/RequestEncoder.swift
+++ b/Core/Sources/SMTP/RequestEncoder.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import Foundation
 import MIME

--- a/Core/Sources/SMTP/ResponseHandler.swift
+++ b/Core/Sources/SMTP/ResponseHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 
 enum Response {

--- a/Core/Sources/SMTP/SMTPClient.swift
+++ b/Core/Sources/SMTP/SMTPClient.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import Network
 import NIOCore

--- a/Core/Sources/SMTP/SMTPError.swift
+++ b/Core/Sources/SMTP/SMTPError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// ``SMTPClient`` throws `SMTPError`.
 public enum SMTPError: Error, CustomStringConvertible, Equatable {
     case emailRecipientNotFound

--- a/Core/Sources/SMTP/SendHandler.swift
+++ b/Core/Sources/SMTP/SendHandler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import NIOCore
 import NIOSSL

--- a/Core/Sources/SMTP/Server.swift
+++ b/Core/Sources/SMTP/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 /// ``SMTPClient`` connects to `Server`.
 public struct Server: CustomStringConvertible, Equatable, Sendable {
     public let connectionSecurity: ConnectionSecurity

--- a/Core/Tests/AccountTests/AccountErrorTests.swift
+++ b/Core/Tests/AccountTests/AccountErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/AccountManagerTests.swift
+++ b/Core/Tests/AccountTests/AccountManagerTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/AccountTests.swift
+++ b/Core/Tests/AccountTests/AccountTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/AuthorizationTests.swift
+++ b/Core/Tests/AccountTests/AuthorizationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/DeletePolicyTests.swift
+++ b/Core/Tests/AccountTests/DeletePolicyTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/FileManagerTests.swift
+++ b/Core/Tests/AccountTests/FileManagerTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/ServerTests.swift
+++ b/Core/Tests/AccountTests/ServerTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/URLCredentialStorageTests.swift
+++ b/Core/Tests/AccountTests/URLCredentialStorageTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AccountTests/URLProtectionSpaceTests.swift
+++ b/Core/Tests/AccountTests/URLProtectionSpaceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Account
 import Testing
 import Foundation

--- a/Core/Tests/AutoconfigurationTests/DNSResolverTests.swift
+++ b/Core/Tests/AutoconfigurationTests/DNSResolverTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Testing
 

--- a/Core/Tests/AutoconfigurationTests/DomainParserTests.swift
+++ b/Core/Tests/AutoconfigurationTests/DomainParserTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/EmailAddressTests.swift
+++ b/Core/Tests/AutoconfigurationTests/EmailAddressTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/OAuth2Tests.swift
+++ b/Core/Tests/AutoconfigurationTests/OAuth2Tests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/SRVRecordTests.swift
+++ b/Core/Tests/AutoconfigurationTests/SRVRecordTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/SRVResolverTests.swift
+++ b/Core/Tests/AutoconfigurationTests/SRVResolverTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Testing
 

--- a/Core/Tests/AutoconfigurationTests/SuffixListParserTests.swift
+++ b/Core/Tests/AutoconfigurationTests/SuffixListParserTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
+++ b/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/URLSessionTests.swift
+++ b/Core/Tests/AutoconfigurationTests/URLSessionTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/URLTests.swift
+++ b/Core/Tests/AutoconfigurationTests/URLTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/AutoconfigurationTests/XMLToJSONParserTests.swift
+++ b/Core/Tests/AutoconfigurationTests/XMLToJSONParserTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import Autoconfiguration
 import Foundation
 import Testing

--- a/Core/Tests/EmailAddressTests/EmailAddressTests.swift
+++ b/Core/Tests/EmailAddressTests/EmailAddressTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import EmailAddress
 import Foundation
 import Testing

--- a/Core/Tests/IMAPTests/CapabilityTests.swift
+++ b/Core/Tests/IMAPTests/CapabilityTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import IMAP
 import Testing
 

--- a/Core/Tests/IMAPTests/FlagTests.swift
+++ b/Core/Tests/IMAPTests/FlagTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import IMAP
 import Testing
 

--- a/Core/Tests/IMAPTests/IMAPClientTests.swift
+++ b/Core/Tests/IMAPTests/IMAPClientTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import IMAP
 import MIME

--- a/Core/Tests/IMAPTests/IMAPErrorTests.swift
+++ b/Core/Tests/IMAPTests/IMAPErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import IMAP
 import Testing

--- a/Core/Tests/IMAPTests/InternetMessageDateTests.swift
+++ b/Core/Tests/IMAPTests/InternetMessageDateTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import IMAP
 import MIME

--- a/Core/Tests/IMAPTests/MailboxTests.swift
+++ b/Core/Tests/IMAPTests/MailboxTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import IMAP
 import Testing
 

--- a/Core/Tests/IMAPTests/MessageTests.swift
+++ b/Core/Tests/IMAPTests/MessageTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import IMAP
 import Testing
 

--- a/Core/Tests/IMAPTests/Server.swift
+++ b/Core/Tests/IMAPTests/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import IMAP
 import Testing
 

--- a/Core/Tests/IMAPTests/ServerMessageDateFormatterTests.swift
+++ b/Core/Tests/IMAPTests/ServerMessageDateFormatterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import IMAP
 import MIME

--- a/Core/Tests/IMAPTests/VoidCommandTests.swift
+++ b/Core/Tests/IMAPTests/VoidCommandTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import IMAP
 import Testing
 

--- a/Core/Tests/JMAPTests/AccountTests.swift
+++ b/Core/Tests/JMAPTests/AccountTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/AuthorizationTests.swift
+++ b/Core/Tests/JMAPTests/AuthorizationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/EmailTests.swift
+++ b/Core/Tests/JMAPTests/EmailTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/JMAPClientTests.swift
+++ b/Core/Tests/JMAPTests/JMAPClientTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import JMAP
 import Testing
 

--- a/Core/Tests/JMAPTests/JMAPErrorTests.swift
+++ b/Core/Tests/JMAPTests/JMAPErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/JSONDecoderTests.swift
+++ b/Core/Tests/JMAPTests/JSONDecoderTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/LocaleTests.swift
+++ b/Core/Tests/JMAPTests/LocaleTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/MailboxTests.swift
+++ b/Core/Tests/JMAPTests/MailboxTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/MethodErrorTests.swift
+++ b/Core/Tests/JMAPTests/MethodErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/RequestErrorTests.swift
+++ b/Core/Tests/JMAPTests/RequestErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/Server.swift
+++ b/Core/Tests/JMAPTests/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import JMAP
 import Testing
 

--- a/Core/Tests/JMAPTests/SessionTests.swift
+++ b/Core/Tests/JMAPTests/SessionTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/SetErrorTests.swift
+++ b/Core/Tests/JMAPTests/SetErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/ThreadTests.swift
+++ b/Core/Tests/JMAPTests/ThreadTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/URLRequestTests.swift
+++ b/Core/Tests/JMAPTests/URLRequestTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/URLSessionTests.swift
+++ b/Core/Tests/JMAPTests/URLSessionTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/JMAPTests/URLTests.swift
+++ b/Core/Tests/JMAPTests/URLTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import JMAP
 import Testing

--- a/Core/Tests/MIMETests/BodyTests.swift
+++ b/Core/Tests/MIMETests/BodyTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/BoundaryTests.swift
+++ b/Core/Tests/MIMETests/BoundaryTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/Bundle.swift
+++ b/Core/Tests/MIMETests/Bundle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 extension Bundle {

--- a/Core/Tests/MIMETests/CharacterSetTests.swift
+++ b/Core/Tests/MIMETests/CharacterSetTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import MIME
 import Testing
 

--- a/Core/Tests/MIMETests/ContentDispositionTests.swift
+++ b/Core/Tests/MIMETests/ContentDispositionTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/ContentTransferEncodingTests.swift
+++ b/Core/Tests/MIMETests/ContentTransferEncodingTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/ContentTypeTests.swift
+++ b/Core/Tests/MIMETests/ContentTypeTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import MIME
 import Testing
 

--- a/Core/Tests/MIMETests/MIMEErrorTests.swift
+++ b/Core/Tests/MIMETests/MIMEErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import MIME
 import Testing
 

--- a/Core/Tests/MIMETests/PartTests.swift
+++ b/Core/Tests/MIMETests/PartTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/RFC822DateFormatterTests.swift
+++ b/Core/Tests/MIMETests/RFC822DateFormatterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/StringTests.swift
+++ b/Core/Tests/MIMETests/StringTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/MIMETests/UUIDTests.swift
+++ b/Core/Tests/MIMETests/UUIDTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 @testable import MIME
 import Testing

--- a/Core/Tests/SMTPTests/EmailTests.swift
+++ b/Core/Tests/SMTPTests/EmailTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 import MIME
 @testable import SMTP

--- a/Core/Tests/SMTPTests/RequestEncoderTests.swift
+++ b/Core/Tests/SMTPTests/RequestEncoderTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import NIOCore
 @testable import SMTP
 import Testing

--- a/Core/Tests/SMTPTests/SMTPClientTests.swift
+++ b/Core/Tests/SMTPTests/SMTPClientTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import EmailAddress
 import Foundation
 import MIME

--- a/Core/Tests/SMTPTests/SMTPErrorTests.swift
+++ b/Core/Tests/SMTPTests/SMTPErrorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 @testable import SMTP
 import Testing
 

--- a/Core/Tests/SMTPTests/Server.swift
+++ b/Core/Tests/SMTPTests/Server.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SMTP
 import Testing
 

--- a/Thunderbird.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Thunderbird.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string> ___FILENAME___
+// ___PROJECTNAME___
+//
+// Created by ___FULLUSERNAME___ on ___DATE___.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+</string>
+</dict>
+</plist>

--- a/Thunderbird/Thunderbird/Account/AccountsView.swift
+++ b/Thunderbird/Thunderbird/Account/AccountsView.swift
@@ -1,3 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 import Account
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/Account/AddAccountView.swift
+++ b/Thunderbird/Thunderbird/Account/AddAccountView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Account
 import Autoconfiguration
 import SwiftUI

--- a/Thunderbird/Thunderbird/Account/AuthorizationView.swift
+++ b/Thunderbird/Thunderbird/Account/AuthorizationView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Account
 import AuthenticationServices
 import Autoconfiguration

--- a/Thunderbird/Thunderbird/Account/AutoconfigView.swift
+++ b/Thunderbird/Thunderbird/Account/AutoconfigView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/Account/EditAccountView.swift
+++ b/Thunderbird/Thunderbird/Account/EditAccountView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/s
+
 import Account
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/Account/EditServerView.swift
+++ b/Thunderbird/Thunderbird/Account/EditServerView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Account
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/Account/OAuth2.swift
+++ b/Thunderbird/Thunderbird/Account/OAuth2.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Autoconfiguration
 import Foundation
 

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Account
 import AuthenticationServices
 import Autoconfiguration

--- a/Thunderbird/Thunderbird/AccountAuth/AccountInformation.swift
+++ b/Thunderbird/Thunderbird/AccountAuth/AccountInformation.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 8/28/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account

--- a/Thunderbird/Thunderbird/AccountAuth/EmailAccountTypeSelection.swift
+++ b/Thunderbird/Thunderbird/AccountAuth/EmailAccountTypeSelection.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 8/18/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account

--- a/Thunderbird/Thunderbird/AccountAuth/ManualAccount.swift
+++ b/Thunderbird/Thunderbird/AccountAuth/ManualAccount.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 7/22/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account

--- a/Thunderbird/Thunderbird/AccountAuth/ManualServerSetup.swift
+++ b/Thunderbird/Thunderbird/AccountAuth/ManualServerSetup.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 8/18/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account

--- a/Thunderbird/Thunderbird/AccountList/DrawerView.swift
+++ b/Thunderbird/Thunderbird/AccountList/DrawerView.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 4/10/26.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Account
 import SwiftUI

--- a/Thunderbird/Thunderbird/App.swift
+++ b/Thunderbird/Thunderbird/App.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Account
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/ContentView.swift
+++ b/Thunderbird/Thunderbird/ContentView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 import Account
 

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailCellView.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 10/17/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import EmailAddress

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 10/20/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account

--- a/Thunderbird/Thunderbird/EmailDisplay/ReadEmailView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/ReadEmailView.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 10/20/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import WebKit

--- a/Thunderbird/Thunderbird/FeatureFlags/Distribution.swift
+++ b/Thunderbird/Thunderbird/FeatureFlags/Distribution.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 11/6/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 public enum Distribution: Sendable {
     case debug

--- a/Thunderbird/Thunderbird/FeatureFlags/FeatureFlagDebugView.swift
+++ b/Thunderbird/Thunderbird/FeatureFlags/FeatureFlagDebugView.swift
@@ -4,6 +4,10 @@
 //
 //  Created by Ashley Soucar on 11/14/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 struct FeatureFlagDebugView: View {

--- a/Thunderbird/Thunderbird/FeatureFlags/FeatureFlags.swift
+++ b/Thunderbird/Thunderbird/FeatureFlags/FeatureFlags.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 11/6/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 private let allowRemoteFlags = "allowRemoteFeatureFlags"

--- a/Thunderbird/Thunderbird/Settings/GeneralSettingsView.swift
+++ b/Thunderbird/Thunderbird/Settings/GeneralSettingsView.swift
@@ -4,6 +4,10 @@
 //
 //  Created by Ashley Soucar on 4/17/26.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 import Account
 

--- a/Thunderbird/Thunderbird/Util/AlertManager.swift
+++ b/Thunderbird/Thunderbird/Util/AlertManager.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 11/26/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 

--- a/Thunderbird/Thunderbird/Util/FeatureNotImplementedView.swift
+++ b/Thunderbird/Thunderbird/Util/FeatureNotImplementedView.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 11/25/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 

--- a/Thunderbird/Thunderbird/Util/NumEntryWrapper.swift
+++ b/Thunderbird/Thunderbird/Util/NumEntryWrapper.swift
@@ -4,6 +4,10 @@
 //
 //  Created by Ashley Soucar on 8/26/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 struct NumEntryWrapper: View {

--- a/Thunderbird/Thunderbird/Util/SmartDateFormatter.swift
+++ b/Thunderbird/Thunderbird/Util/SmartDateFormatter.swift
@@ -4,6 +4,10 @@
 //
 //  Created by Ashley Soucar on 3/6/26.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 @MainActor

--- a/Thunderbird/Thunderbird/Util/TempEmailModel.swift
+++ b/Thunderbird/Thunderbird/Util/TempEmailModel.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 12/5/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 

--- a/Thunderbird/Thunderbird/Util/TextEntryWrapper.swift
+++ b/Thunderbird/Thunderbird/Util/TextEntryWrapper.swift
@@ -4,6 +4,10 @@
 //
 //  Created by Ashley Soucar on 8/26/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 struct TextEntryWrapper: View {

--- a/Thunderbird/Thunderbird/WelcomeScreen.swift
+++ b/Thunderbird/Thunderbird/WelcomeScreen.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 
 struct WelcomeScreen: View {

--- a/Thunderbird/ThunderbirdTests/FeatureFlagTests.swift
+++ b/Thunderbird/ThunderbirdTests/FeatureFlagTests.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 11/19/25.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 import Testing

--- a/Thunderbird/ThunderbirdTests/UtilTests/SmartDateFormatterTests.swift
+++ b/Thunderbird/ThunderbirdTests/UtilTests/SmartDateFormatterTests.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Ashley Soucar on 3/6/26.
 //
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 import Testing


### PR DESCRIPTION
## Contribution Summary
Closes #334, adds new file header to include the MPL2 license to all new files created by XCode in the project, and adds license to current files
This does not include lint checks

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
