### PR TITLE
fix: iOS 18 Startup Crash

### DIFF
--- a/.github/workflows/shippable-builds.yml
+++ b/.github/workflows/shippable-builds.yml
@@ -6,7 +6,7 @@ env:
   DEFAULT_VERSION: &default_version "1.0"
   DEFAULT_NOTIFY_TESTERS: &default_notify_testers false
   DEFAULT_TEST_DEVICE: &default_test_device "iPhone 17"
-  XCODE_VERSION: "26.0"
+  XCODE_VERSION: "26.1"
 
 on:
   schedule:

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -87,6 +87,7 @@ struct EmailListView: View {
                                 }
                             )
                             .listRowSeparator(.hidden)
+                            .navigationLinkIndicatorVisibility(.hidden)
                         }
                     }.environment(\.editMode, $editMode)
                         .listStyle(.plain)


### PR DESCRIPTION
## Contribution Summary
When Apple backported the `.navigationLinkIndicatorVisibility` feature to iOS 17 and 18 they did it improperly. This was fixed in XCode 26.1. To fix we have to build the app with XCode 26.1 or later

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.

Fixes #348 

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
