### PR TITLE
feat(account): JMAP mailbox operations

### DIFF
--- a/Core/Sources/Account/MailboxManager.swift
+++ b/Core/Sources/Account/MailboxManager.swift
@@ -26,10 +26,11 @@ public final class MailboxManager {
                 let client: IMAPClient = try await account.imapClient
                 try await client.create(mailbox: IMAP.Mailbox.Name(name))
                 mailboxes.append(Mailbox(name))
-                await refreshMailboxes()
             case .jmap:
-                throw JMAPError.method(.unknownMethod)
+                let client: JMAPClient = try await account.jmapClient
+                try await client.create(mailbox: JMAP.Mailbox(name: name))
             }
+            await refreshMailboxes()
         } catch {
             self.error = AccountError(error)
         }
@@ -41,10 +42,11 @@ public final class MailboxManager {
             case .imap:
                 let client: IMAPClient = try await account.imapClient
                 try await client.rename(mailbox: IMAP.Mailbox.Name(mailbox.name), to: IMAP.Mailbox.Name(name))
-                await refreshMailboxes()
             case .jmap:
-                throw JMAPError.method(.unknownMethod)
+                let client: JMAPClient = try await account.jmapClient
+                try await client.update(mailbox: JMAP.Mailbox(name: name, isSubscribed: mailbox.isSubscribed, id: mailbox.id))
             }
+            await refreshMailboxes()
         } catch {
             self.error = AccountError(error)
         }
@@ -56,10 +58,11 @@ public final class MailboxManager {
             case .imap:
                 let client: IMAPClient = try await account.imapClient
                 try await client.delete(mailbox: IMAP.Mailbox.Name(mailbox.name))
-                await refreshMailboxes()
             case .jmap:
-                throw JMAPError.method(.unknownMethod)
+                let client: JMAPClient = try await account.jmapClient
+                try await client.destroy(mailbox: JMAP.Mailbox(name: mailbox.name, id: mailbox.id))
             }
+            await refreshMailboxes()
         } catch {
             self.error = AccountError(error)
         }
@@ -71,10 +74,11 @@ public final class MailboxManager {
             case .imap:
                 let client: IMAPClient = try await account.imapClient
                 try await client.subscribe(mailbox: IMAP.Mailbox.Name(mailbox.name))
-                await refreshMailboxes()
             case .jmap:
-                throw JMAPError.method(.unknownMethod)
+                let client: JMAPClient = try await account.jmapClient
+                try await client.update(mailbox: JMAP.Mailbox(name: mailbox.name, isSubscribed: true, id: mailbox.id))
             }
+            await refreshMailboxes()
         } catch {
             self.error = AccountError(error)
         }
@@ -86,10 +90,11 @@ public final class MailboxManager {
             case .imap:
                 let client: IMAPClient = try await account.imapClient
                 try await client.unsubscribe(mailbox: IMAP.Mailbox.Name(mailbox.name))
-                await refreshMailboxes()
             case .jmap:
-                throw JMAPError.method(.unknownMethod)
+                let client: JMAPClient = try await account.jmapClient
+                try await client.update(mailbox: JMAP.Mailbox(name: mailbox.name, isSubscribed: false, id: mailbox.id))
             }
+            await refreshMailboxes()
         } catch {
             self.error = AccountError(error)
         }

--- a/Core/Sources/JMAP/JMAPClient.swift
+++ b/Core/Sources/JMAP/JMAPClient.swift
@@ -93,6 +93,69 @@ public class JMAPClient {
         }
     }
 
+    /// Create a new mailbox.
+    @discardableResult public func create(mailbox: Mailbox) async throws -> MethodSetResponse? {
+        guard let session, let accountID: String = session.accounts.keys.first else {
+            throw JMAPError.method(.accountNotFound)
+        }
+        logger?.info("Creating \"\(mailbox.name)\" mailbox…")
+        return try await URLSession.shared.jmapAPI(
+            [
+                Mailbox.SetMethod(
+                    accountID,
+                    actions: [
+                        .create([
+                            mailbox.id: [
+                                "name": mailbox.name,
+                                "isSubscribed": mailbox.isSubscribed
+                            ]
+                        ])
+                    ])
+            ], url: session.apiURL, authorization: server.authorization!
+        ).first as? MethodSetResponse
+    }
+
+    /// Update an existing mailbox.
+    @discardableResult public func update(mailbox: Mailbox) async throws -> MethodSetResponse? {
+        guard let session, let accountID: String = session.accounts.keys.first else {
+            throw JMAPError.method(.accountNotFound)
+        }
+        logger?.info("Updating \"\(mailbox.name)\" mailbox…")
+        return try await URLSession.shared.jmapAPI(
+            [
+                Mailbox.SetMethod(
+                    accountID,
+                    actions: [
+                        .update([
+                            mailbox.id: [
+                                "name": mailbox.name,
+                                "isSubscribed": mailbox.isSubscribed
+                            ]
+                        ])
+                    ])
+            ], url: session.apiURL, authorization: server.authorization!
+        ).first as? MethodSetResponse
+    }
+
+    /// Destroy an existing mailbox.
+    @discardableResult public func destroy(mailbox: Mailbox) async throws -> MethodSetResponse? {
+        guard let session, let accountID: String = session.accounts.keys.first else {
+            throw JMAPError.method(.accountNotFound)
+        }
+        logger?.info("Destroying \"\(mailbox.name)\" mailbox…")
+        return try await URLSession.shared.jmapAPI(
+            [
+                Mailbox.SetMethod(
+                    accountID,
+                    actions: [
+                        .destroy([
+                            mailbox.id
+                        ])
+                    ])
+            ], url: session.apiURL, authorization: server.authorization!
+        ).first as? MethodSetResponse
+    }
+
     public func mailboxes() async throws -> [Mailbox] {
         if let session {
             guard let id: String = session.accounts.keys.first else {

--- a/Core/Sources/JMAP/Mailbox.swift
+++ b/Core/Sources/JMAP/Mailbox.swift
@@ -62,7 +62,7 @@ public struct Mailbox: CustomStringConvertible, Decodable, Equatable, Hashable, 
 
     public var rights: Rights { myRights }  // Rename `myRights` to `rights`
 
-    public init(name: String, parentID: String? = nil, isSubscribed: Bool = true, id: String) {
+    public init(name: String, parentID: String? = nil, isSubscribed: Bool = true, id: String? = nil) {
         self.name = name
         self.parentID = parentID
         role = nil
@@ -73,7 +73,7 @@ public struct Mailbox: CustomStringConvertible, Decodable, Equatable, Hashable, 
         unreadThreads = 0
         self.isSubscribed = isSubscribed
         myRights = Rights()
-        self.id = id
+        self.id = id ?? "NOID"  // Non-empty, client-provided temporary ID: https://jmap.io/spec/rfc8620/#section-5.3-3.3.1
     }
 
     let myRights: Rights


### PR DESCRIPTION
## Contribution Summary

Building out common mailboxes for `Account` core library, from #345 and #356:

* Extend `MailboxManager` public interface with JMAP implementations for mailbox operations: create, rename, delete, subscribe and unsubscribe 

Close #340

## Screenshots

<video src="https://github.com/user-attachments/assets/446366d5-436c-43eb-bcaa-6b595a64398e"></video>

Demo app lives in [`demo-core-libraries` branch](https://github.com/toddheasley/thunderbird-ios/tree/demo-core-libraries) of my dev fork.

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
