### PR TITLE
Add multi_json dependency to fastlane Gemfile

### DIFF
--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "multi_json"


### PR DESCRIPTION
representable uses multi_json but doesn't declare it in its gemspec: https://github.com/trailblazer/representable/blob/master/representable.gemspec

And other libraries recently dropped multi_json:
https://github.com/googleapis/google-auth-library-ruby/releases/tag/googleauth%2Fv1.17.0 https://github.com/googleapis/signet/releases/tag/signet%2Fv0.22.0

Fixes: #371