### PR TITLE
fix: JMAP update spec URLs

### DIFF
--- a/Core/README.md
+++ b/Core/README.md
@@ -220,7 +220,7 @@ try await SMTPClient(Server(
 
 [JSON Meta Application Protocol](https://jmap.io) (JMAP)) is a modern, API-based approach to email that uses standard HTTP requests and responses with JSON serialization for transit.
 
-`JMAP` library is a client implementation of both [JMAP core](https://jmap.io/spec-core.html) and [JMAP mail](https://jmap.io/spec-mail.html) protocols, with functionality tailored for use in [Thunderbird iOS.](https://github.com/thunderbird/thunderbird-ios)
+`JMAP` library is a client implementation of both [JMAP core](https://jmap.io/spec/rfc8620) and [JMAP mail](https://jmap.io/spec/rfc8621) protocols, with functionality tailored for use in [Thunderbird iOS.](https://github.com/thunderbird/thunderbird-ios)
 
 JMAP support is early and experimental.
 

--- a/Core/Sources/JMAP/Account.swift
+++ b/Core/Sources/JMAP/Account.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Accounts are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)
+/// Accounts are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec/rfc8620/#section-2)
 public struct Account: CustomStringConvertible, Decodable, Sendable {
     public let name: String
     public let capabilities: [Capability.Key: Capability]

--- a/Core/Sources/JMAP/Capability.swift
+++ b/Core/Sources/JMAP/Capability.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Capabilities are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)
+/// Capabilities are a component of the JMAP ``Session`` object, part of [JMAP core.](https://jmap.io/spec/rfc8620/#section-2)
 public struct Capability: Decodable, Sendable {
     public enum Key: String, CaseIterable, Codable, CustomStringConvertible, Identifiable, Sendable {
         case calendars = "urn:ietf:params:jmap:calendars"

--- a/Core/Sources/JMAP/Email.swift
+++ b/Core/Sources/JMAP/Email.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UniformTypeIdentifiers
 
-/// `Email` represents a single message, pre-decoded and modeled, no client-side MIME parsing required; part of [JMAP mail protocol.](https://jmap.io/spec-mail.html#emails)
+/// `Email` represents a single message, pre-decoded and modeled, no client-side MIME parsing required; part of [JMAP mail protocol.](https://jmap.io/spec/rfc8621/#section-4)
 public struct Email: Decodable, Equatable, Hashable, Identifiable, Sendable {
     public struct Address: CustomStringConvertible, Decodable, Equatable, Sendable {
         public let email: String

--- a/Core/Sources/JMAP/Filter.swift
+++ b/Core/Sources/JMAP/Filter.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Filters narrow the returned responses when querying ``Email``, part of [JMAP core.](https://jmap.io/spec-core.html#query)
+/// Filters narrow the returned responses when querying ``Email``, part of [JMAP core.](https://jmap.io/spec/rfc8620/#section-5.5)
 public struct Filter: CustomStringConvertible {
     public protocol Condition: CustomStringConvertible {
         var key: String { get }

--- a/Core/Sources/JMAP/JSONDecoder.swift
+++ b/Core/Sources/JMAP/JSONDecoder.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension JSONDecoder {
 
-    // https://jmap.io/spec-core.html#the-date-and-utcdate-data-types
+    // https://jmap.io/spec/rfc8620/#section-1.4
     convenience init(date decodingStrategy: DateDecodingStrategy) {
         self.init()
         dateDecodingStrategy = decodingStrategy

--- a/Core/Sources/JMAP/Locale.swift
+++ b/Core/Sources/JMAP/Locale.swift
@@ -8,7 +8,7 @@ extension Locale {
 
     /// Generate a weighted `Accept-Language` HTTP request header matching the device's configured locales.
     ///
-    /// JMAP services _should_ [localize user-facing strings](https://jmap.io/spec-core.html#localisation-of-user-visible-strings) according to  header value.
+    /// JMAP services _should_ [localize user-facing strings](https://jmap.io/spec/rfc8620/#section-3.8) according to  header value.
     public static func acceptedLanguages() -> String {
         var languages: [String] = []
         for (index, language) in preferredLanguages.prefix(5).enumerated() {

--- a/Core/Sources/JMAP/Mailbox.swift
+++ b/Core/Sources/JMAP/Mailbox.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Mailboxes are the primary mechanism for organizing ``Email`` within an ``Account``, part of [JMAP mail.](https://jmap.io/spec-mail.html#mailboxes)
+/// Mailboxes are the primary mechanism for organizing ``Email`` within an ``Account``, part of [JMAP mail.](https://jmap.io/spec/rfc8621/#section-2)
 public struct Mailbox: CustomStringConvertible, Decodable, Equatable, Hashable, Identifiable, Sendable {
     public enum Role: String, CaseIterable, CustomStringConvertible, Decodable, Identifiable, Sendable {
         case inbox, archive, drafts, sent, junk, trash

--- a/Core/Sources/JMAP/Method.swift
+++ b/Core/Sources/JMAP/Method.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Standard request object, part of [JMAP core](https://jmap.io/spec-core.html#the-request-object)
+/// Standard request object, part of [JMAP core](https://jmap.io/spec/rfc8620/#section-5)
 public protocol Method: Identifiable {
     static var name: String { get }
     var accountID: String { get }

--- a/Core/Sources/JMAP/MethodAction.swift
+++ b/Core/Sources/JMAP/MethodAction.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Possible `set` ``Method`` mutations, part of [JMAP corel](https://jmap.io/spec-core.html#set)
+/// Possible `set` ``Method`` mutations, part of [JMAP corel](https://jmap.io/spec/rfc8620/#section-5.3)
 public enum MethodAction: CustomStringConvertible {
     case create([String: Any])
     case update([String: Any])

--- a/Core/Sources/JMAP/MethodError.swift
+++ b/Core/Sources/JMAP/MethodError.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Errors describing impossible or ineligible``Method`` operation, part of [JMAP core](https://jmap.io/spec-core.html#errors)
+/// Errors describing impossible or ineligible``Method`` operation, part of [JMAP core](https://jmap.io/spec/rfc8620/#section-3.6)
 public enum MethodError: String, CaseIterable, CustomStringConvertible, Decodable, Error, Identifiable {
     case accountNotFound, accountNotSupportedByMethod, accountReadOnly
     case forbidden

--- a/Core/Sources/JMAP/MethodResponse.swift
+++ b/Core/Sources/JMAP/MethodResponse.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Standard ``Method`` responses with generic response components modeled, part of [JMAP core](https://jmap.io/spec-core.html#the-response-object)
+/// Standard ``Method`` responses with generic response components modeled, part of [JMAP core](https://jmap.io/spec/rfc8620/#section-3.4)
 public protocol MethodResponse: Identifiable {
     var name: String { get }
     var id: UUID { get }

--- a/Core/Sources/JMAP/RequestError.swift
+++ b/Core/Sources/JMAP/RequestError.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Request-level configuration errors, part of [JMAP core](https://jmap.io/spec-core.html#errors)
+/// Request-level configuration errors, part of [JMAP core](https://jmap.io/spec/rfc8620/#section-3.6)
 public struct RequestError: Error, Decodable, CustomStringConvertible {
 
     /// Enumerated error code derived from `type` raw value

--- a/Core/Sources/JMAP/Session.swift
+++ b/Core/Sources/JMAP/Session.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Sessions include details about the data and capabilities the server can provide to the client, part of [JMAP core.](https://jmap.io/spec-core.html#the-jmap-session-resource)
+/// Sessions include details about the data and capabilities the server can provide to the client, part of [JMAP core.](https://jmap.io/spec/rfc8620/#section-2)
 public struct Session: CustomStringConvertible, Decodable, Equatable, Sendable {
     public let username: String
     public let accounts: [String: Account]

--- a/Core/Sources/JMAP/Thread.swift
+++ b/Core/Sources/JMAP/Thread.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Threads group replies to an ``Email`` message , part of [JMAP mail.](https://jmap.io/spec-mail.html#threads)
+/// Threads group replies to an ``Email`` message , part of [JMAP mail.](https://jmap.io/spec/rfc8621/#section-3)
 public struct Thread: Decodable, Identifiable {
     public let emailIDs: [String]
 

--- a/Core/Sources/JMAP/URLSession.swift
+++ b/Core/Sources/JMAP/URLSession.swift
@@ -34,7 +34,7 @@ extension URLSession {
             switch name.components(separatedBy: "/").last {
             case "get":
 
-                // Map generic parts of [get response.](https://jmap.io/spec-core.html#get)
+                // Map generic parts of [get response.](https://jmap.io/spec/rfc8620/#section-5.1)
                 guard let notFound: [String] = object["notFound"] as? [String],
                     let list: [Any] = object["list"] as? [Any]
                 else {
@@ -46,7 +46,7 @@ extension URLSession {
                 return MethodGetResponse(name, data: data, notFound: notFound, id: id)
             case "query":
 
-                // Map generic parts of [query response.](https://jmap.io/spec-core.html#query)
+                // Map generic parts of [query response.](https://jmap.io/spec/rfc8620/#section-5.5)
                 guard let ids: [String] = object["ids"] as? [String],
                     let position: Int = object["position"] as? Int,
                     let total: Int = object["total"] as? Int
@@ -56,7 +56,7 @@ extension URLSession {
                 return MethodQueryResponse(name, ids: ids, position: position, total: total, id: id)
             case "set":
 
-                // Map generic parts of [set response.](https://jmap.io/spec-core.html#set)
+                // Map generic parts of [set response.](https://jmap.io/spec/rfc8620/#section-5.3)
                 func mapErrorValues(for key: String) -> [String: SetError] {
                     (object[key] as? [String: Any] ?? [:])
                         .mapValues { SetError($0) ?? .notFound }

--- a/Thunderbird/Thunderbird/Documentation.docc/Design.md
+++ b/Thunderbird/Thunderbird/Documentation.docc/Design.md
@@ -38,7 +38,7 @@ Separate, complementary libraries handle email retrieval and sending for all mai
 
 #### `JMAP`
 
- [JSON Meta Application Protocol](https://jmap.io) (JMAP)) is a modern, API-based approach to email that uses standard HTTP requests and responses with JSON serialization for transit. `JMAP` feature library is a client implementation of both [JMAP core](https://jmap.io/spec-core.html) and [JMAP mail](https://jmap.io/spec-mail.html) protocols, intended to replace IMAP/SMTP for mail accounts with provider support for JMAP.
+ [JSON Meta Application Protocol](https://jmap.io) (JMAP)) is a modern, API-based approach to email that uses standard HTTP requests and responses with JSON serialization for transit. `JMAP` feature library is a client implementation of both [JMAP core](https://jmap.io/spec/rfc8620) and [JMAP mail](https://jmap.io/spec/rfc8621) protocols, intended to replace IMAP/SMTP for mail accounts with provider support for JMAP.
 
 ### Bolt Package
 


### PR DESCRIPTION
## Contribution Summary

[jmap.io](https://jmap.io) changed URL format w/ no redirect for old links.

Close #376

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
