### PR TITLE
feat(account): JMAP adopt common email address

### DIFF
--- a/Core/Sources/EmailAddress/EmailAddress.swift
+++ b/Core/Sources/EmailAddress/EmailAddress.swift
@@ -9,7 +9,7 @@ public protocol EmailAddressProtocol: Sendable {
 }
 
 /// Shared email address model suitable for IMAP, JMAP and SMTP
-public struct EmailAddress: Codable, CustomStringConvertible, Equatable, EmailAddressProtocol, ExpressibleByStringLiteral, Hashable, Identifiable {
+public struct EmailAddress: CustomStringConvertible, EmailAddressProtocol, ExpressibleByStringLiteral, Hashable, Identifiable, Sendable {
     public let value: String
     public let label: String?
 
@@ -35,28 +35,11 @@ public struct EmailAddress: Codable, CustomStringConvertible, Equatable, EmailAd
         }
     }
 
-    // MARK: Codable
-    public func encode(to encoder: any Encoder) throws {
-        var container: SingleValueEncodingContainer = encoder.singleValueContainer()
-        try container.encode(description)
-    }
-
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let value: String = try container.decode(String.self)
-        self.init(stringLiteral: value)
-    }
-
     // MARK: CustomStringConvertible
     public var description: String { !(label ?? "").isEmpty ? "\(label!) <\(value)>" : value }
 
     // MARK: EmailAddressProtocol
     public var addresses: [Self] { [self] }
-
-    // MARK: Equatable
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id  // Equality ignores label
-    }
 
     // MARK: ExpressibleByStringLiteral
     public init(stringLiteral value: StringLiteralType) {
@@ -70,7 +53,7 @@ public struct EmailAddress: Codable, CustomStringConvertible, Equatable, EmailAd
 extension EmailAddress {
 
     /// Shared email address group/list model suitable for IMAP and JMAP
-    public struct Group: EmailAddressProtocol {
+    public struct Group: EmailAddressProtocol, Equatable, Sendable {
         public let label: String?
         public let email: [EmailAddressProtocol]
 
@@ -82,5 +65,11 @@ extension EmailAddress {
 
         // MARK: EmailAddressProtocol
         public var addresses: [EmailAddress] { email.flatMap { $0.addresses } }
+
+        // MARK: Equatable
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            // Equality ignores labels, positions and grouping
+            lhs.addresses.map({ $0.id }).sorted() == rhs.addresses.map({ $0.id }).sorted()
+        }
     }
 }

--- a/Core/Sources/JMAP/Email.swift
+++ b/Core/Sources/JMAP/Email.swift
@@ -2,31 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import EmailAddress
 import Foundation
 import UniformTypeIdentifiers
 
 /// `Email` represents a single message, pre-decoded and modeled, no client-side MIME parsing required; part of [JMAP mail protocol.](https://jmap.io/spec/rfc8621/#section-4)
 public struct Email: Decodable, Equatable, Hashable, Identifiable, Sendable {
-    public struct Address: CustomStringConvertible, Decodable, Equatable, Sendable {
-        public let email: String
-        public let name: String?
-
-        init(_ email: String, name: String? = nil) {
-            self.email = email
-            self.name = name
-        }
-
-        // MARK: CustomStringConvertible
-        public var description: String {
-            !(name ?? "").isEmpty ? "\"\(name!)\" <\(email)>" : "\(email)"
-        }
-    }
-
-    public struct AddressGroup: Decodable, Equatable {
-        public let adresses: [Address]
-        public let name: String?
-    }
-
     public enum Keyword: String, CaseIterable, CustomStringConvertible, Sendable {
         case draft = "$draft"
         case seen = "$seen"
@@ -111,12 +92,12 @@ public struct Email: Decodable, Equatable, Hashable, Identifiable, Sendable {
     public let messageID: [String]?
     public let inReplyTo: [String]?
     public let references: [String]?
-    public let sender: [Address]?
-    public let from: [Address]?
-    public let replyTo: [Address]?
-    public let to: [Address]?
-    public let cc: [Address]?
-    public let bcc: [Address]?
+    public let sender: [EmailAddressProtocol]?
+    public let from: [EmailAddressProtocol]?
+    public let replyTo: [EmailAddressProtocol]?
+    public let to: [EmailAddressProtocol]?
+    public let cc: [EmailAddressProtocol]?
+    public let bcc: [EmailAddressProtocol]?
     public let subject: String?
     public let bodyStructure: BodyPart?
     // public let bodyValues: Any?
@@ -140,12 +121,12 @@ public struct Email: Decodable, Equatable, Hashable, Identifiable, Sendable {
         messageID = try container.decodeIfPresent([String].self, forKey: .messageId)
         inReplyTo = try container.decodeIfPresent([String].self, forKey: .inReplyTo)
         references = try container.decodeIfPresent([String].self, forKey: .references)
-        sender = try container.decodeIfPresent([Address].self, forKey: .sender)
-        from = try container.decodeIfPresent([Address].self, forKey: .from)
-        replyTo = try container.decodeIfPresent([Address].self, forKey: .replyTo)
-        to = try container.decodeIfPresent([Address].self, forKey: .to)
-        cc = try container.decodeIfPresent([Address].self, forKey: .cc)
-        bcc = try container.decodeIfPresent([Address].self, forKey: .bcc)
+        sender = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .sender)
+        from = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .from)?.erased()
+        replyTo = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .replyTo)?.erased()
+        to = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .to)?.erased()
+        cc = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .cc)?.erased()
+        bcc = try container.decodeIfPresent([EmailAddress.Group].self, forKey: .bcc)?.erased()
         subject = try container.decodeIfPresent(String.self, forKey: .subject)
         bodyStructure = try container.decodeIfPresent(BodyPart.self, forKey: .bodyStructure)
         textBody = try container.decode([BodyPart].self, forKey: .textBody)

--- a/Core/Sources/JMAP/EmailAddress.swift
+++ b/Core/Sources/JMAP/EmailAddress.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import EmailAddress
+import Foundation
+
+/// Extend common `EmailAddress` to decode/encode and behave like [JMAP's `EmailAddress` type.](https://jmap.io/spec/rfc8621/#section-4.1.2.3-3)
+extension EmailAddress: Codable {
+    public var email: String { value }
+    public var name: String? { label }
+
+    // MARK: Codable
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer = encoder.container(keyedBy: Key.self)
+        try container.encode(value, forKey: .email)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        if let container: SingleValueDecodingContainer = try? decoder.singleValueContainer(),
+            let string: String = try? container.decode(String.self)
+        {
+            // Maintain backward compatibility with previous encoding as string
+            self.init(stringLiteral: string)
+        } else {
+            let container: KeyedDecodingContainer = try decoder.container(keyedBy: Key.self)
+            let email: String = try container.decode(String.self, forKey: .email)
+            let name: String? = try container.decodeIfPresent(String.self, forKey: .name)
+            self.init(email, label: name)
+        }
+    }
+}
+
+/// Extend common `EmailAddress.Group` to decode/encode and behave like [JMAP's `EmailAddressGroup` type.](https://jmap.io/spec/rfc8621/#section-4.1.2.4-3)
+extension EmailAddress.Group: Codable {
+    public var name: String? { label }
+
+    func erased() -> EmailAddressProtocol {
+        guard name == nil && addresses.count == 1 else {
+            return self as EmailAddressProtocol
+        }
+        return addresses[0] as EmailAddressProtocol  // Single address can be losslessly unwrapped
+    }
+
+    // MARK: Codable
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer = encoder.container(keyedBy: Key.self)
+        try container.encode(addresses, forKey: .addresses)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer = try decoder.container(keyedBy: Key.self)
+        let name: String? = try container.decodeIfPresent(String.self, forKey: .name)
+        if let email: String = try container.decodeIfPresent(String.self, forKey: .email) {
+            // JMAP `address-list` can be either group or single address: https://jmap.io/spec/rfc8621/#section-4.1.2.4-7
+            // Decode single address as group of one
+            self.init([
+                EmailAddress(email, label: name)
+            ])
+        } else {
+            // JMAP groups are homogenous, limited to email addresses; no sub-groups
+            let addresses: [EmailAddress] = try container.decode([EmailAddress].self, forKey: .addresses)
+            self.init(addresses, label: name)
+        }
+    }
+}
+
+extension [EmailAddress.Group] {
+    func erased() -> [EmailAddressProtocol] {
+        map { $0.erased() }
+    }
+}
+
+private enum Key: CodingKey {
+    case addresses, email, name
+}

--- a/Core/Tests/EmailAddressTests/EmailAddressTests.swift
+++ b/Core/Tests/EmailAddressTests/EmailAddressTests.swift
@@ -37,23 +37,6 @@ struct EmailAddressTests {
         #expect(EmailAddress("name@example.com").label == nil)
     }
 
-    // MARK: Codable
-    @Test func encode() throws {
-        #expect(try JSONEncoder().encode(EmailAddress("name@example.com", label: "Example Name")) == "\"Example Name <name@example.com>\"".data(using: .utf8))
-        #expect(try JSONEncoder().encode(EmailAddress("name@example.com")) == "\"name@example.com\"".data(using: .utf8))
-    }
-
-    @Test func decoderInit() throws {
-        let data: [Data] = [
-            "\"Example Name <name@example.com>\"".data(using: .utf8)!,
-            "\"name@example.com\"".data(using: .utf8)!
-        ]
-        #expect(try JSONDecoder().decode(EmailAddress.self, from: data[0]).value == "name@example.com")
-        #expect(try JSONDecoder().decode(EmailAddress.self, from: data[0]).label == "Example Name")
-        #expect(try JSONDecoder().decode(EmailAddress.self, from: data[1]).value == "name@example.com")
-        #expect(try JSONDecoder().decode(EmailAddress.self, from: data[1]).label == nil)
-    }
-
     // MARK: ExpressibleByStringLiteral
     @Test func stringLiteralInit() {
         let labeledEmailAddress: EmailAddress = "Example Name <name@example.com>"

--- a/Core/Tests/JMAPTests/EmailAddressTests.swift
+++ b/Core/Tests/JMAPTests/EmailAddressTests.swift
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import EmailAddress
+import Foundation
+@testable import JMAP
+import Testing
+
+struct EmailAddressTests {
+
+    // MARK: Codable
+    @Test func encode() throws {
+        /*
+        #expect(try JSONEncoder().encode(EmailAddress("name@example.com", label: "Example Name")) == "\"Example Name <name@example.com>\"".data(using: .utf8))
+        #expect(try JSONEncoder().encode(EmailAddress("name@example.com")) == "\"name@example.com\"".data(using: .utf8)) */
+    }
+
+    @Test func decoderInit() throws {
+        let emailAddresses: [EmailAddressProtocol] = try JSONDecoder().decode([EmailAddress.Group].self, from: data).erased()
+        #expect(emailAddresses.count == 5)
+        #expect((emailAddresses[0] as? EmailAddress.Group)?.name == "Named Group")
+        #expect((emailAddresses[0] as? EmailAddress.Group)?.addresses.count == 2)
+        #expect((emailAddresses[1] as? EmailAddress)?.email == "emptyname@example.com")
+        #expect((emailAddresses[1] as? EmailAddress)?.name == nil)
+        #expect((emailAddresses[2] as? EmailAddress)?.email == "nullname@example.com")
+        #expect((emailAddresses[2] as? EmailAddress)?.name == nil)
+        #expect((emailAddresses[3] as? EmailAddress)?.email == "noname@example.com")
+        #expect((emailAddresses[3] as? EmailAddress)?.name == nil)
+        #expect((emailAddresses[4] as? EmailAddress)?.email == "name@example.com")
+        #expect((emailAddresses[4] as? EmailAddress)?.name == "Named Example")
+
+        // Test backward compatibility with previous encoding as string
+        let string: Data = "\"Named Example <name@example.com>\"".data(using: .utf8)!
+        let emailAddress: EmailAddress = try JSONDecoder().decode(EmailAddress.self, from: string)
+        #expect(emailAddress.email == "name@example.com")
+        #expect(emailAddress.name == "Named Example")
+    }
+}
+
+// swift-format-ignore
+private let data: Data = """
+[
+    {
+        "addresses": [
+            {
+                "email": "name@example.com",
+                "name": "Named Example"
+            },
+            {
+                "email": "noname@example.com"
+            }
+        ],
+        "name": "Named Group"
+    },
+    {
+        "email": "emptyname@example.com",
+        "name": ""
+    },
+    {
+        "email": "nullname@example.com",
+        "name": null
+    },
+    {
+        "addresses": [
+            {
+                "email": "noname@example.com"
+            }
+        ]
+    },
+    {
+        "email": "name@example.com",
+        "name": "Named Example"
+    }
+]
+""".data(using: .utf8)!

--- a/Core/Tests/JMAPTests/EmailTests.swift
+++ b/Core/Tests/JMAPTests/EmailTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import EmailAddress
 import Foundation
 @testable import JMAP
 import Testing
@@ -10,7 +11,6 @@ struct EmailTests {
     @Test func decoderInit() throws {
         let emails: [Email] = try JSONDecoder(date: .iso8601).decode([Email].self, from: data)
         try #require(emails.count == 2)
-
         #expect(emails[0].blobID == "G8a183cc18aec2b46bd7b7f11c81d65783d400482")
         #expect(emails[0].threadID == "T1bebe52081852054")
         #expect(
@@ -35,13 +35,13 @@ struct EmailTests {
         #expect(emails[0].references == nil)
         #expect(emails[0].sender == nil)
         #expect(
-            emails[0].from == [
-                Email.Address("user@example.com", name: "Example User")
+            emails[0].from?.first?.addresses == [
+                EmailAddress("user@example.com", label: "Example User")
             ])
         #expect(emails[0].replyTo == nil)
         #expect(
-            emails[0].to == [
-                Email.Address("recipient@example.com")
+            emails[0].to?.first?.addresses == [
+                EmailAddress("recipient@example.com")
             ])
         #expect(emails[0].cc == nil)
         #expect(emails[0].bcc == nil)
@@ -102,13 +102,13 @@ struct EmailTests {
             ])
         #expect(emails[1].sender == nil)
         #expect(
-            emails[1].from == [
-                Email.Address("recipient@example.com", name: "Example User")
+            emails[1].from?.first?.addresses == [
+                EmailAddress("recipient@example.com", label: "Example User")
             ])
         #expect(emails[1].replyTo == nil)
         #expect(
-            emails[1].to == [
-                Email.Address("user@example.com", name: "Example User")
+            emails[1].to?.first?.addresses == [
+                EmailAddress("user@example.com", label: "Example User")
             ])
         #expect(emails[1].cc == nil)
         #expect(emails[1].bcc == nil)

--- a/Core/Tests/SMTPTests/EmailTests.swift
+++ b/Core/Tests/SMTPTests/EmailTests.swift
@@ -22,9 +22,9 @@ struct EmailTests {
     @Test func allRecipients() {
         #expect(
             Email.example.allRecipients == [
-                "recipient@example.com",
+                "Recipient Name <recipient@example.com>",
                 "no.name@exmaple.com",
-                "cc@example.com",
+                "Copied Recipient <cc@example.com>",
                 "bcc@example.com"
             ]
         )


### PR DESCRIPTION
## Contribution Summary

Move JSON `Codable` conformance of common `EmailAddress` model into `JMAP` library; re-implement encoding and decoding based on JMAP types for `EmailAddress` and `EmailAddress.Group`

Because `EmailAddress` is a modeled JMAP type, the easier solution is to let JMAP do its own thing, and convert between JMAP and common address types as needed. By extending the common `EmailAddress` to _be_ the native JMAP type instead, common `EmailAddress` can be used from core libs to view models and observable app UI, no conversion needed.

Close #375

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
