### PR TITLE
Compose Headers V1

### DIFF
--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -6,52 +6,57 @@
 //
 
 import SwiftUI
+import Account
 
 struct ComposeHeaderView: View {
+    @Environment(Accounts.self) private var accounts: Accounts
+
     @State var subject: String = ""
-    @State var sender: [String] = [""]
     @State var toRecipients: [String] = []
+    @State var replyToRecipients: [String] = []
     @State var ccRecipients: [String] = []
     @State var bccRecipients: [String] = []
+    @State var selectedSender: UUID = UUID()
+    @State var showCCBCC: Bool = false
+    @State var showReplyTo: Bool = false
 
     var body: some View {
         VStack {
-            VStack {
-                List {
-                    AddressBar("From", $sender)
+            List {
+                HStack {
+                    Picker("From", selection: $selectedSender) {
+                        ForEach(accounts.allAccounts) { account in
+                            Text(account.name).tag(account.id)
+                        }
+                    } currentValueLabel: {
+                        Text(accounts.account(for: selectedSender)?.name ?? "")
+                    }.pickerStyle(.menu)
+                    Spacer()
+                    if !showReplyTo {
+                        Button("", systemImage: "chevron.down") {
+                            showReplyTo = true
+                        }.foregroundStyle(.black)
+                    }
+                }
+                if showReplyTo {
+                    MultiAddressBar("Reply To", $replyToRecipients)
+                }
+                HStack(alignment: .top) {
                     MultiAddressBar("To", $toRecipients)
+                    if !showCCBCC {
+                        Button("", systemImage: "chevron.down") {
+                            showCCBCC = true
+                        }.foregroundStyle(.black)
+                    }
+                }
+                if showCCBCC {
                     MultiAddressBar("CC", $ccRecipients)
                     MultiAddressBar("BCC", $bccRecipients)
-                    TextField("Subject", text: $subject)
-                }.frame(alignment: .leading)
-                    .font(.subheadline)
-
-            }
-
-        }
-    }
-}
-
-struct AddressBar: View {
-    init(
-        _ header: LocalizedStringResource = "",
-        _ entryText: Binding<[String]>,
-    ) {
-        headerText = header
-        _entryText = entryText
-    }
-    private var headerText: LocalizedStringResource
-    @Binding private var entryText: [String]
-
-    // MARK: View
-    var body: some View {
-        HStack {
-            Text(headerText)
-            HStack {
-                ForEach(entryText, id: \.self) { email in
-                    EmailPill(email, $entryText)
                 }
-            }
+
+                TextField("Subject", text: $subject)
+            }.frame(alignment: .leading)
+                .font(.subheadline)
         }
     }
 }
@@ -70,24 +75,29 @@ struct MultiAddressBar: View {
 
     // MARK: View
     var body: some View {
-        HStack {
-            Text(headerText)
-                .fixedSize()
-            TextField("", text: $entryString)
-                .textFieldStyle(.plain)
-                .autocorrectionDisabled()
-                .autocapitalization(.none)
-                .focusable()
-                .onSubmit {
-                    entryText.append(entryString)
-                    entryString = ""
+        VStack(alignment: .leading) {
+            HStack {
+                Text(headerText)
+                    .fixedSize()
+                TextField("", text: $entryString)
+                    .textFieldStyle(.plain)
+                    .autocorrectionDisabled()
+                    .autocapitalization(.none)
+                    .focusable()
+                    .onSubmit {
+                        if entryString.isEmailAddress {
+                            entryText.append(entryString)
+                            entryString = ""
+                        }
+                    }
+            }
+            HStackWrap {
+                ForEach(entryText, id: \.self) { email in
+                    EmailPill(email, $entryText)
                 }
-        }
-        VStack {
-            ForEach(entryText, id: \.self) { email in
-                EmailPill(email, $entryText)
             }
         }
+
     }
 }
 
@@ -116,5 +126,10 @@ struct EmailPill: View {
     }
 }
 #Preview {
-    ComposeHeaderView(sender: ["me@me.com"], toRecipients: ["me@mer1.com", "me@mer2.com", "mer3@me.com"], bccRecipients: ["mebcc@me.com"])
+    @Previewable @State var accounts: Accounts = Accounts()
+    ComposeHeaderView(
+        toRecipients: ["me@mer1.com", "me@mer2.com", "mer3@me.com"],
+        bccRecipients: ["mebcc@me.com"]
+    )
+    .environment(accounts)
 }

--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -24,7 +24,7 @@ struct ComposeHeaderView: View {
         VStack {
             List {
                 HStack {
-                    Picker("From", selection: $selectedSender) {
+                    Picker("from_header", selection: $selectedSender) {
                         ForEach(accounts.allAccounts) { account in
                             Text(account.name).tag(account.id)
                         }
@@ -39,10 +39,10 @@ struct ComposeHeaderView: View {
                     }
                 }
                 if showReplyTo {
-                    MultiAddressBar("Reply To", $replyToRecipients)
+                    MultiAddressBar("reply_to_header", $replyToRecipients)
                 }
                 HStack(alignment: .top) {
-                    MultiAddressBar("To", $toRecipients)
+                    MultiAddressBar("to_header", $toRecipients)
                     if !showCCBCC {
                         Button("", systemImage: "chevron.down") {
                             showCCBCC = true
@@ -50,11 +50,11 @@ struct ComposeHeaderView: View {
                     }
                 }
                 if showCCBCC {
-                    MultiAddressBar("CC", $ccRecipients)
-                    MultiAddressBar("BCC", $bccRecipients)
+                    MultiAddressBar("cc_header", $ccRecipients)
+                    MultiAddressBar("bcc_header", $bccRecipients)
                 }
 
-                TextField("Subject", text: $subject)
+                TextField("subject_header", text: $subject)
             }.frame(alignment: .leading)
                 .font(.subheadline)
         }
@@ -113,7 +113,7 @@ struct EmailPill: View {
         HStack {
             Text(emailAddress)
                 .fixedSize(horizontal: true, vertical: false)
-            Label("Remove", systemImage: "x.circle").labelStyle(.iconOnly)
+            Label("remove_button", systemImage: "x.circle").labelStyle(.iconOnly)
                 .onTapGesture {
                     entries.remove(at: entries.firstIndex(of: emailAddress)!)
                 }
@@ -127,9 +127,6 @@ struct EmailPill: View {
 }
 #Preview {
     @Previewable @State var accounts: Accounts = Accounts()
-    ComposeHeaderView(
-        toRecipients: ["me@mer1.com", "me@mer2.com", "mer3@me.com"],
-        bccRecipients: ["mebcc@me.com"]
-    )
-    .environment(accounts)
+    ComposeHeaderView()
+        .environment(accounts)
 }

--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -1,0 +1,120 @@
+//
+//  ComposeHeaderView.swift
+//  Thunderbird
+//
+//  Created by Ashley Soucar on 2/18/26.
+//
+
+import SwiftUI
+
+struct ComposeHeaderView: View {
+    @State var subject: String = ""
+    @State var sender: [String] = [""]
+    @State var toRecipients: [String] = []
+    @State var ccRecipients: [String] = []
+    @State var bccRecipients: [String] = []
+
+    var body: some View {
+        VStack {
+            VStack {
+                List {
+                    AddressBar("From", $sender)
+                    MultiAddressBar("To", $toRecipients)
+                    MultiAddressBar("CC", $ccRecipients)
+                    MultiAddressBar("BCC", $bccRecipients)
+                    TextField("Subject", text: $subject)
+                }.frame(alignment: .leading)
+                    .font(.subheadline)
+
+            }
+
+        }
+    }
+}
+
+struct AddressBar: View {
+    init(
+        _ header: LocalizedStringResource = "",
+        _ entryText: Binding<[String]>,
+    ) {
+        headerText = header
+        _entryText = entryText
+    }
+    private var headerText: LocalizedStringResource
+    @Binding private var entryText: [String]
+
+    // MARK: View
+    var body: some View {
+        HStack {
+            Text(headerText)
+            HStack {
+                ForEach(entryText, id: \.self) { email in
+                    EmailPill(email, $entryText)
+                }
+            }
+        }
+    }
+}
+
+struct MultiAddressBar: View {
+    init(
+        _ header: LocalizedStringResource = "",
+        _ entryText: Binding<[String]>,
+    ) {
+        headerText = header
+        _entryText = entryText
+    }
+    private var headerText: LocalizedStringResource
+    @Binding private var entryText: [String]
+    @State private var entryString: String = ""
+
+    // MARK: View
+    var body: some View {
+        HStack {
+            Text(headerText)
+                .fixedSize()
+            TextField("", text: $entryString)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                .autocapitalization(.none)
+                .focusable()
+                .onSubmit {
+                    entryText.append(entryString)
+                    entryString = ""
+                }
+        }
+        VStack {
+            ForEach(entryText, id: \.self) { email in
+                EmailPill(email, $entryText)
+            }
+        }
+    }
+}
+
+struct EmailPill: View {
+    init(_ email: String, _ currentEntries: Binding<[String]>) {
+        emailAddress = email
+        _entries = currentEntries
+    }
+    @State private var emailAddress: String
+    @Binding private var entries: [String]
+
+    var body: some View {
+        HStack {
+            Text(emailAddress)
+                .fixedSize(horizontal: true, vertical: false)
+            Label("Remove", systemImage: "x.circle").labelStyle(.iconOnly)
+                .onTapGesture {
+                    entries.remove(at: entries.firstIndex(of: emailAddress)!)
+                }
+        }.padding(2)
+            .background {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.gray.opacity(0.2))
+                    .stroke(.gray, lineWidth: 1)
+            }
+    }
+}
+#Preview {
+    ComposeHeaderView(sender: ["me@me.com"], toRecipients: ["me@mer1.com", "me@mer2.com", "mer3@me.com"], bccRecipients: ["mebcc@me.com"])
+}

--- a/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
@@ -1,0 +1,29 @@
+//
+//  ComposeView.swift
+//  Thunderbird
+//
+//  Created by Ashley Soucar on 2/18/26.
+//
+
+import SwiftUI
+
+struct ComposeView: View {
+    @State private var demoHtml: String = "<h1>Hello World</h1>"
+    @State private var rawText = NSAttributedString(string: "")
+
+    var body: some View {
+        VStack {
+            ComposeHeaderView()
+
+        }.toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                }) {
+                    Image(systemName: "archivebox")
+                        .foregroundStyle(.foreground)
+                }
+            }
+        }
+
+    }
+}

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailListView.swift
@@ -17,6 +17,7 @@ struct EmailListView: View {
     @State var editMode: EditMode = .inactive
     @State private var selections = Set<UUID>()
     @State private var showDrawer = false
+    @State private var path = NavigationPath()
 
     //Hardcoded for testing
     let attributedString = try? NSMutableAttributedString(
@@ -53,7 +54,7 @@ struct EmailListView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ZStack(alignment: .bottomTrailing) {
                 if tempEmails.isEmpty {
                     VStack {
@@ -93,7 +94,7 @@ struct EmailListView: View {
                         .scrollContentBackground(.hidden)
                 }
                 Button {
-                    // Action
+                    path.append("compose")
                 } label: {
                     Image("compose")
                         .font(.title.weight(.regular))
@@ -105,10 +106,15 @@ struct EmailListView: View {
                 }
                 .background(.clear)
                 .padding()
-                .disabled(true)
+                .navigationDestination(for: String.self) { destination in
+                    if destination == "compose" {
+                        ComposeView()
+                    }
+                }
                 DrawerView(showDrawer: $showDrawer)
             }
             .navigationTitle("inbox_header")
+
             .navigationBarBackButtonHidden(editMode.isEditing)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {

--- a/Thunderbird/Thunderbird/Localization/en.lproj/Localizable.strings
+++ b/Thunderbird/Thunderbird/Localization/en.lproj/Localizable.strings
@@ -57,6 +57,7 @@
 "bcc_header" = "BCC";
 "copy_header" = "Copy";
 "blind_copy_header" = "Blind Copy";
+"subject_header" = "Subject";
 
 
 // Other
@@ -92,6 +93,8 @@
 "forward_button" = "Forward";
 "forward_as_button" = "Forward as attachment";
 "edit_as_new_button" = "Edit as new";
+"remove_button" = "remove";
+
 //Email List Actions
 "mark_all_read_button" = "Mark all read";
 "select_all_button" = "Select All";

--- a/Thunderbird/Thunderbird/Util/HStackWrap.swift
+++ b/Thunderbird/Thunderbird/Util/HStackWrap.swift
@@ -1,0 +1,82 @@
+// HStackWrap.swift
+// Thunderbird
+//
+// Created by Ashley Soucar on 6/24/26.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+
+import SwiftUI
+
+struct HStackWrap: Layout {
+    private let horizontalSpacing: CGFloat
+    private let verticalSpacing: CGFloat
+
+    public init(
+        horizontalSpacing: CGFloat = 6,
+        verticalSpacing: CGFloat = 5
+    ) {
+        self.horizontalSpacing = horizontalSpacing
+        self.verticalSpacing = verticalSpacing
+    }
+
+    public func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        var width = 0.0
+        var height = 0.0
+        var rowHeight = 0.0
+        var rowWidth = 0.0
+        let maxWidth = proposal.width ?? .infinity
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+
+            if rowWidth + size.width > maxWidth {
+                width = max(rowWidth, maxWidth)
+                height += rowHeight + verticalSpacing
+                rowWidth = 0
+                rowHeight = 0
+            }
+
+            rowWidth += size.width + horizontalSpacing
+            rowHeight = max(rowHeight, size.height)
+        }
+
+        width = max(width, rowWidth)
+        height += rowHeight
+
+        return CGSize(width: width, height: height)
+    }
+
+    public func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        var currentX = bounds.minX
+        var currentY = bounds.minY
+        let maxWidth = bounds.maxX
+
+        for subview in subviews {
+            let size = subview.dimensions(in: .unspecified)
+
+            if currentX + size.width > maxWidth {
+                currentY += size.height + verticalSpacing
+                currentX = bounds.minX
+            }
+
+            subview.place(
+                at: CGPoint(x: currentX, y: currentY),
+                proposal: .unspecified
+            )
+
+            currentX += size.width + horizontalSpacing
+        }
+    }
+}


### PR DESCRIPTION
## Summary
UI for the headers associated with sending an email. This includes from, reply to, to, copy, blind copy, and subject. Hooks in to Accounts for sender and allows for multiple inputs for other fields. Final UI from design still TBD

Close #235 

## Screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-26 at 12 11 43" src="https://github.com/user-attachments/assets/11f843fe-4386-4e34-85cd-2329cbd1d915" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-26 at 12 11 48" src="https://github.com/user-attachments/assets/74753bc2-efb5-4f23-a98e-0a9e2e0aaca5" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-26 at 12 11 49" src="https://github.com/user-attachments/assets/20c8bf1e-6845-4424-a6a6-8c054c362a86" />


## AI Contribution Disclosure

- [x] This contribution does not include any changes created or assisted by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [ ] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [ ] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
