### PR TITLE
feat(account): integrate common email model

### DIFF
--- a/Core/Sources/Account/Email.swift
+++ b/Core/Sources/Account/Email.swift
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import EmailAddress
+import Foundation
+import IMAP
+import JMAP
+import MIME
+
+/// Common `Email` model represents and losslessly converts to and from both ``IMAP.Message`` and ``JMAP.Email``
+public struct Email: CustomStringConvertible, Identifiable, Sendable {
+    public let from: [EmailAddressProtocol]
+    public let sender: [EmailAddressProtocol]
+    public let replyTo: [EmailAddressProtocol]
+    public let to: [EmailAddressProtocol]
+    public let bcc: [EmailAddressProtocol]
+    public let cc: [EmailAddressProtocol]
+    public let received: Date?  // IMAP internal message date
+    public let sent: Date?  // IMAP envelope date
+    public let messageID: [String]
+    public let threadID: [String]
+    public let inReplyTo: [String]
+    public let subject: String?
+    public let body: Body?
+
+    public init(
+        from: [EmailAddressProtocol] = [],
+        sender: [EmailAddressProtocol] = [],
+        replyTo: [EmailAddressProtocol] = [],
+        to: [EmailAddressProtocol] = [],
+        bcc: [EmailAddressProtocol] = [],
+        cc: [EmailAddressProtocol] = [],
+        received: Date? = nil,
+        sent: Date? = nil,
+        messageID: [String] = [],
+        threadID: [String] = [],
+        inReplyTo: [String] = [],
+        subject: String? = nil,
+        body: Body? = nil,
+        id: String? = nil
+    ) {
+        self.from = from
+        self.sender = sender
+        self.replyTo = replyTo
+        self.to = to
+        self.bcc = bcc
+        self.cc = cc
+        self.received = received
+        self.sent = sent
+        self.messageID = messageID
+        self.threadID = threadID
+        self.inReplyTo = inReplyTo
+        self.subject = subject
+        self.body = body
+        self.id = id ?? UUID().uuidString(1)
+    }
+
+    // MARK: CustomStringConvertible
+    public var description: String { messageID.first ?? id }
+
+    // MARK: Identifiable
+    public let id: String  // IMAP message ID
+}
+
+extension Email {
+    // Decode Gmail message ID, if present
+    var gmailMessageID: UInt64? {
+        guard let id: UInt64 = UInt64(messageID.last ?? ""), id > .gmailIDFloor else {
+            return nil
+        }
+        return id
+    }
+
+    // Decode Gmail thread ID, if present
+    var gmailThreadID: UInt64? {
+        guard let id: UInt64 = UInt64(threadID.last ?? ""), id > .gmailIDFloor else {
+            return nil
+        }
+        return id
+    }
+
+    // Map from IMAP message
+    init(_ message: IMAP.Message) {
+        self.init(
+            from: message.envelope.from,
+            sender: message.envelope.sender,
+            replyTo: message.envelope.reply,
+            to: message.envelope.to,
+            bcc: message.envelope.bcc,
+            cc: message.envelope.cc,
+            received: message.internalDate,  // IMAP internal message date
+            sent: message.envelope.date?.date,  // IMAP envelope date; forget sender time zone
+            messageID: message.messageIDs,
+            threadID: message.threadIDs,
+            inReplyTo: message.inReplyTo,
+            subject: message.envelope.subject,
+            body: message.body,
+            id: message.emailID ?? message.gmailID
+        )
+    }
+
+    // Map from JMAP email
+    init(_ email: JMAP.Email) {
+        self.init(
+            from: email.from ?? [],
+            sender: email.sender ?? [],
+            replyTo: email.replyTo ?? [],
+            to: email.to ?? [],
+            bcc: email.bcc ?? [],
+            cc: email.cc ?? [],
+            received: email.receivedAt,
+            sent: email.sentAt,
+            messageID: email.messageID ?? [],
+            threadID: [email.threadID],
+            inReplyTo: email.inReplyTo ?? [],
+            subject: email.subject,
+            body: nil,
+            id: email.id
+        )
+    }
+}
+
+extension IMAP.Message {
+
+    // Use `gmailMessageID` as ID string, if present
+    var gmailID: String? { gmailMessageID != nil ? "\(gmailMessageID!)" : nil }
+
+    // Collect available message IDs, plain and/or Gmail flavored
+    var messageIDs: [String] {
+        var ids: [String] = []
+        if let id: String = envelope.messageID {
+            ids.append(id)
+        }
+        if let id: UInt64 = gmailMessageID {
+            ids.append("\(id)")
+        }
+        return ids
+    }
+
+    // Collect available thread IDs, plain and/or Gmail flavored
+    var threadIDs: [String] {
+        var ids: [String] = []
+        if let id: String = threadID {
+            ids.append(id)
+        }
+        if let id: UInt64 = gmailThreadID {
+            ids.append("\(id)")
+        }
+        return ids
+    }
+
+    var inReplyTo: [String] {
+        var ids: [String] = []
+        if let id: String = envelope.inReplyTo {
+            ids.append(id)
+        }
+        return ids
+    }
+}
+
+private extension UInt64 {
+    static let gmailIDFloor: Self = 1_000_000_000_000
+}

--- a/Core/Sources/Account/Mailbox.swift
+++ b/Core/Sources/Account/Mailbox.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
 /// Common mailbox model represents a single JMAP or IMAP mailbox, folder or Gmail label.
@@ -54,7 +58,7 @@ extension Mailbox {
             isSubscribed: !mailbox.0.attributes.filter({ $0 == .subscribed }).isEmpty,
             unreadEmails: mailbox.1?.unseenCount,
             totalEmails: mailbox.1?.messageCount,
-            id: id  // Transfer UUID or autogenenrate new one
+            id: id ?? UUID().uuidString(1)  // Transfer UUID or autogenenrate new one
         )
     }
 

--- a/Core/Sources/Account/MailboxManager.swift
+++ b/Core/Sources/Account/MailboxManager.swift
@@ -1,6 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Foundation
 
-/// Manage and display mailboxes for a given `Account`.
+/// Manage and display mailboxes for a given ``Account``.
 @Observable
 public final class MailboxManager {
     public let account: Account
@@ -17,6 +21,25 @@ public final class MailboxManager {
 
     public func mailbox(for id: String) -> Mailbox? {
         mailboxes.filter({ $0.id == id }).first
+    }
+
+    public func emails(in mailbox: Mailbox) async -> [Email] {
+        do {
+            switch account.emailProtocol {
+            case .imap:
+                let client: IMAPClient = try await account.imapClient
+                try await client.select(mailbox: IMAP.Mailbox.Name(mailbox.name))
+                let messages: MessageSet = try await client.fetch()
+                return messages.keys.sorted().reversed().map { Email(messages[$0]!) }
+            case .jmap:
+                let client: JMAPClient = try await account.jmapClient
+                let emails: [JMAP.Email] = try await client.emails(in: JMAP.Mailbox(name: mailbox.name, id: mailbox.id))
+                return emails.map { Email($0) }
+            }
+        } catch {
+            self.error = AccountError(error)
+            return []
+        }
     }
 
     public func createMailbox(_ name: String) async {

--- a/Core/Sources/IMAP/IMAPClient.swift
+++ b/Core/Sources/IMAP/IMAPClient.swift
@@ -105,7 +105,7 @@ public class IMAPClient {
     public func noop() async throws -> [IdleEvent] {
         logger?.info("Noop…")
         guard !isIdling else {
-            // NIOIMAP automatically (1) keeps idle alive and (2) streams idle events
+            // NIOIMAP automatically keeps idle alive and streams idle events
             // Manual `noop` polling is blocked by NIOIMAP during idle
             throw IMAPError.commandNotSupported("Noop during idle")
         }
@@ -119,21 +119,21 @@ public class IMAPClient {
     }
 
     /// Select current working mailbox in read/write mode.
-    @discardableResult public func select(mailbox: Mailbox) async throws -> Mailbox.Status {
-        logger?.info("Selecting mailbox \(mailbox.path.name)…")
-        return try await execute(command: SelectCommand(mailbox.path.name))
+    @discardableResult public func select(mailbox name: MailboxName) async throws -> Mailbox.Status {
+        logger?.info("Selecting mailbox \(name)…")
+        return try await execute(command: SelectCommand(name))
     }
 
     /// Select a working mailbox in read-only mode.
-    public func examine(mailbox: Mailbox) async throws -> Mailbox.Status {
-        logger?.info("Examining mailbox \(mailbox.path.name)…")
-        return try await execute(command: ExamineCommand(mailbox.path.name))
+    public func examine(mailbox name: MailboxName) async throws -> Mailbox.Status {
+        logger?.info("Examining mailbox \(name)…")
+        return try await execute(command: ExamineCommand(name))
     }
 
     /// Fetch the current status for a mailbox.
-    public func status(mailbox: Mailbox) async throws -> Mailbox.Status {
-        logger?.info("Refreshing mailbox \(mailbox.path.name) status…")
-        return try await execute(command: StatusCommand(mailbox.path.name, attributes: .standard + .extended(capabilities)))
+    public func status(mailbox name: MailboxName) async throws -> Mailbox.Status {
+        logger?.info("Refreshing mailbox \(name) status…")
+        return try await execute(command: StatusCommand(name, attributes: .standard + .extended(capabilities)))
     }
 
     /// Expunge messages flagged as deleted in current working mailbox.

--- a/Core/Sources/JMAP/Email.swift
+++ b/Core/Sources/JMAP/Email.swift
@@ -107,6 +107,58 @@ public struct Email: Decodable, Equatable, Hashable, Identifiable, Sendable {
     public let hasAttachment: Bool
     public let preview: String?
 
+    public init(
+        blobID: String,
+        threadID: String,
+        mailboxIDs: [String: Bool] = [:],
+        keywords: [String: Bool] = [:],
+        size: Int,
+        receivedAt: Date? = nil,
+        sentAt: Date? = nil,
+        messageID: [String]? = nil,
+        inReplyTo: [String]? = nil,
+        references: [String]? = nil,
+        sender: [EmailAddressProtocol]? = nil,
+        from: [EmailAddressProtocol]? = nil,
+        replyTo: [EmailAddressProtocol]? = nil,
+        to: [EmailAddressProtocol]? = nil,
+        cc: [EmailAddressProtocol]? = nil,
+        bcc: [EmailAddressProtocol]? = nil,
+        subject: String? = nil,
+        bodyStructure: BodyPart? = nil,
+        textBody: [BodyPart] = [],
+        htmlBody: [BodyPart] = [],
+        attachments: [BodyPart] = [],
+        hasAttachment: Bool = false,
+        preview: String? = nil,
+        id: String
+    ) {
+        self.blobID = blobID
+        self.threadID = threadID
+        self.mailboxIDs = mailboxIDs
+        self.keywords = keywords
+        self.size = size
+        self.receivedAt = receivedAt
+        self.sentAt = sentAt
+        self.messageID = messageID
+        self.inReplyTo = inReplyTo
+        self.references = references
+        self.sender = sender
+        self.from = from
+        self.replyTo = replyTo
+        self.to = to
+        self.cc = cc
+        self.bcc = bcc
+        self.subject = subject
+        self.bodyStructure = bodyStructure
+        self.textBody = textBody
+        self.htmlBody = htmlBody
+        self.attachments = attachments
+        self.hasAttachment = hasAttachment
+        self.preview = preview
+        self.id = id
+    }
+
     // MARK: Decodable
     public init(from decoder: any Decoder) throws {
         let container: KeyedDecodingContainer<Key> = try decoder.container(keyedBy: Key.self)

--- a/Core/Tests/AccountTests/EmailTests.swift
+++ b/Core/Tests/AccountTests/EmailTests.swift
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Account
+import Testing
+import Foundation
+
+struct EmailTests {
+    @Test func gmailMessageID() {
+        #expect(Email(IMAP.Message.aol).gmailMessageID == nil)
+        #expect(Email(JMAP.Email.fastmail).gmailMessageID == nil)
+        #expect(Email(IMAP.Message.gmail).gmailMessageID == 1_865_707_498_850_970_206)
+    }
+
+    @Test func gmailThreadID() {
+        #expect(Email(IMAP.Message.aol).gmailThreadID == nil)
+        #expect(Email(JMAP.Email.fastmail).gmailThreadID == nil)
+        #expect(Email(IMAP.Message.gmail).gmailThreadID == 8_509_702_061_865_707_498)
+    }
+
+    @Test func imapMessageInit() {
+        let aol: Email = Email(IMAP.Message.aol)
+        #expect(
+            aol.messageID == [
+                "<4addb7e5-9bfa-48f6-833a-b7cd846064dc@example.com>"
+            ])
+        #expect(aol.subject == "Email activity on account")
+        #expect(aol.sent == Date(timeIntervalSince1970: 1779277275.0))
+        #expect(aol.received == Date(timeIntervalSince1970: 1779277306.0))
+        #expect(aol.from.first as? EmailAddress == "from@aol.com")
+        #expect(aol.from.count == 1)
+        #expect(aol.sender.first as? EmailAddress == "sender@aol.com")
+        #expect(aol.sender.count == 1)
+        #expect(aol.replyTo.first as? EmailAddress == "reply@aol.com")
+        #expect(aol.replyTo.count == 1)
+        #expect(aol.to.first as? EmailAddress == "Example <example@aol.com>")
+        #expect(aol.to.count == 1)
+        #expect(aol.cc.isEmpty)
+        #expect(aol.bcc.isEmpty)
+        #expect(
+            aol.threadID == [
+                "1598"
+            ])
+        #expect(aol.id == "AAYqCTjUMm7xS26Ui3FBV9j4skS")
+
+        let gmail: Email = Email(IMAP.Message.gmail)
+        #expect(
+            gmail.messageID == [
+                "<fd838b6b-4245-406c-91b5-21f5d359135d@example.com>",
+                "1865707498850970206"
+            ])
+        #expect(gmail.subject == "Summer Sale Ends Tomorrow!")
+        #expect(gmail.sent == Date(timeIntervalSince1970: 1781993898.0))
+        #expect(gmail.received == Date(timeIntervalSince1970: 1781993898.0))
+        #expect(gmail.from.first as? EmailAddress == "Mailing List <list@example.com>")
+        #expect(gmail.from.count == 1)
+        #expect(gmail.sender.isEmpty)
+        #expect(gmail.cc.first as? EmailAddress == "copied@gmail.com")
+        #expect(gmail.cc.last as? EmailAddress == "cc@example.com")
+        #expect(gmail.cc.count == 2)
+        #expect(
+            gmail.threadID == [
+                "8509702061865707498"
+            ])
+        #expect(gmail.id == "1865707498850970206")
+    }
+
+    @Test func jmapEmailInit() {
+        let fastmail: Email = Email(JMAP.Email.fastmail)
+        #expect(
+            fastmail.messageID == [
+                "9d937078-84ec-4999-b346-9c4218a14a82@mtasv.net"
+            ])
+        #expect(fastmail.subject == "Your receipt from Fastmail")
+        #expect(fastmail.sent == Date(timeIntervalSince1970: 1772226074.0))
+        #expect(fastmail.received == Date(timeIntervalSince1970: 1772226076.0))
+        #expect(fastmail.sender.isEmpty)
+        #expect(fastmail.from.first as? EmailAddress == "Fastmail <help@fastmail.com>")
+        #expect(fastmail.from.count == 1)
+        #expect(fastmail.replyTo.isEmpty)
+        #expect(fastmail.to.first as? EmailAddress == "example@fastmail.com")
+        #expect(fastmail.to.count == 1)
+        #expect(fastmail.cc.isEmpty)
+        #expect(fastmail.bcc.isEmpty)
+        #expect(
+            fastmail.threadID == [
+                "A-2QEdnnTnWc"
+            ])
+        #expect(fastmail.id == "StqU8lS8UWc7")
+    }
+}
+
+private extension IMAP.Message {
+    static var aol: Self {
+        Self(
+            body: nil,
+            emailID: "AAYqCTjUMm7xS26Ui3FBV9j4skS",
+            envelope: Envelope(
+                subject: "Email activity on account",
+                date: InternetMessageDate(Date(timeIntervalSince1970: 1779277275.0)),
+                from: [
+                    EmailAddress("from@aol.com")
+                ],
+                sender: [
+                    EmailAddress("sender@aol.com")
+                ],
+                reply: [
+                    EmailAddress("reply@aol.com")
+                ],
+                to: [
+                    EmailAddress("example@aol.com", label: "Example")
+                ],
+                cc: [],
+                bcc: [],
+                inReplyTo: nil,
+                messageID: "<4addb7e5-9bfa-48f6-833a-b7cd846064dc@example.com>"
+            ),
+            flags: [],
+            gmailLabels: [],
+            gmailMessageID: nil,
+            gmailThreadID: nil,
+            internalDate: Date(timeIntervalSince1970: 1779277306.0),
+            threadID: "1598",
+            uid: 100307
+        )
+    }
+
+    static var gmail: Self {
+        Self(
+            body: nil,
+            emailID: nil,
+            envelope: Envelope(
+                subject: "Summer Sale Ends Tomorrow!",
+                date: InternetMessageDate(Date(timeIntervalSince1970: 1781993898.0)),
+                from: [
+                    EmailAddress("list@example.com", label: "Mailing List")
+                ],
+                sender: [],
+                reply: [
+                    EmailAddress("reply@example.com")
+                ],
+                to: [
+                    EmailAddress("example@gmail.com", label: "Example")
+                ],
+                cc: [
+                    EmailAddress("copied@gmail.com"),
+                    EmailAddress("cc@example.com")
+                ],
+                bcc: [],
+                inReplyTo: nil,
+                messageID: "<fd838b6b-4245-406c-91b5-21f5d359135d@example.com>"
+            ),
+            flags: [],
+            gmailLabels: [],
+            gmailMessageID: 1_865_707_498_850_970_206,
+            gmailThreadID: 8_509_702_061_865_707_498,
+            internalDate: Date(timeIntervalSince1970: 1781993898.0),
+            threadID: nil,
+            uid: 2963
+        )
+    }
+}
+
+private extension JMAP.Email {
+    static var fastmail: Self {
+        Self(
+            blobID: "G91c5164637b7c508b0bd862634b91b883f5e2970",
+            threadID: "A-2QEdnnTnWc",
+            mailboxIDs: ["J-T": true],
+            keywords: [
+                "$maskedemail": true,
+                "$x-me-annot-2": true,
+                "$hasattachment": true,
+                "$istrusted": true
+            ],
+            size: 117230,
+            receivedAt: Date(timeIntervalSince1970: 1772226076.0),
+            sentAt: Date(timeIntervalSince1970: 1772226074.0),
+            messageID: [
+                "9d937078-84ec-4999-b346-9c4218a14a82@mtasv.net"
+            ],
+            inReplyTo: nil,
+            references: nil,
+            sender: nil,
+            from: [
+                EmailAddress("help@fastmail.com", label: "Fastmail")
+            ],
+            replyTo: nil,
+            to: [
+                EmailAddress("example@fastmail.com")
+            ],
+            cc: nil,
+            bcc: nil,
+            subject: "Your receipt from Fastmail",
+            bodyStructure: nil,
+            textBody: [],
+            htmlBody: [],
+            attachments: [],
+            hasAttachment: false,
+            preview: "Thank you for your purchase! Your full invoice is attached to this email.",
+            id: "StqU8lS8UWc7"
+        )
+    }
+}

--- a/Core/Tests/IMAPTests/IMAPClientTests.swift
+++ b/Core/Tests/IMAPTests/IMAPClientTests.swift
@@ -17,9 +17,9 @@ struct IMAPClientTests {
         guard let inbox: Mailbox = mailboxes.filter({ $0.0.path.name.isInbox }).first?.0 else {
             throw IMAPError.unexpectedResponse("Inbox not found")
         }  // Find inbox in mailbox list
-        try await client.select(mailbox: inbox)  // Select inbox
+        try await client.select(mailbox: inbox.path.name)  // Select inbox
 
-        let status = try await client.status(mailbox: inbox)
+        let status = try await client.status(mailbox: inbox.path.name)
         #expect(status.messageCount != nil && status.messageCount! > 0)
         #expect(status.recentCount != nil && status.recentCount! >= 0)
         #expect(status.unseenCount != nil && status.unseenCount! >= 0)


### PR DESCRIPTION
## Contribution Summary

PR continues implementing `Account` core library, with minor supporting changes to `IMAP` and `JMAP` client interfaces:

* Revise and expand common `Email` model.
* Convert to common `Email` from both `IMAP.Message` and `JMAP.Email`.
* Test conversions using mocked IMAP (plain and Gmail) and JMAP data.
* List emails for IMAP/JMAP mailboxes in `MailboxManager`.

Note that common body/view #370 and common flags/labels/keywords #300 will follow in later PRs.

Close #298; close #368 

## Screenshots

<video src="https://github.com/user-attachments/assets/a7847e86-b92e-4817-b306-553f1c57bfa0"></video>

Demo app lives in [`demo-core-libraries` branch](https://github.com/toddheasley/thunderbird-ios/tree/demo-core-libraries) of my dev fork.

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
