### PR TITLE
feat(account): encode common email to IMAP and JMAP

### DIFF
--- a/Core/Sources/Account/Body.swift
+++ b/Core/Sources/Account/Body.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import JMAP
+import MIME
+
+public typealias Body = MIME.Body
+
+extension Body {
+    init(_ email: JMAP.Email) throws {
+        // TODO: JMAP email body encoding and assembly not implemented
+        throw URLError(.cancelled)
+    }
+}

--- a/Core/Sources/Account/Email.swift
+++ b/Core/Sources/Account/Email.swift
@@ -157,6 +157,37 @@ extension IMAP.Message {
         }
         return ids
     }
+
+    // Map back to IMAP message
+    init(_ email: Email) {
+        self.init(
+            body: email.body,
+            emailID: email.id,
+            envelope: Envelope(
+                subject: email.subject,
+                date: email.sent?.internetMessageDate,
+                from: email.from,
+                sender: email.sender,
+                reply: email.replyTo,
+                to: email.to,
+                cc: email.cc,
+                bcc: email.bcc,
+                inReplyTo: email.inReplyTo.first,
+                messageID: email.messageID.first
+            ),
+            flags: [],
+            gmailLabels: [],
+            gmailMessageID: email.gmailMessageID,
+            gmailThreadID: email.gmailThreadID,
+            internalDate: email.received,
+            threadID: email.threadID.first,
+            uid: nil
+        )
+    }
+}
+
+extension Date {
+    var internetMessageDate: InternetMessageDate { InternetMessageDate(self) }
 }
 
 private extension UInt64 {

--- a/Core/Sources/Account/Email.swift
+++ b/Core/Sources/Account/Email.swift
@@ -24,6 +24,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
     public let subject: String?
     public let body: Body?
     public let blobID: String?
+    public let uid: UID?
 
     public init(
         from: [EmailAddressProtocol] = [],
@@ -40,6 +41,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
         subject: String? = nil,
         body: Body? = nil,
         blobID: String? = nil,
+        uid: UID? = nil,
         id: String? = nil
     ) {
         self.from = from
@@ -56,6 +58,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
         self.subject = subject
         self.body = body
         self.blobID = blobID
+        self.uid = uid
         self.id = id ?? UUID().uuidString(1)
     }
 
@@ -99,6 +102,7 @@ extension Email {
             inReplyTo: message.inReplyTo,
             subject: message.envelope.subject,
             body: message.body,
+            uid: message.uid,
             id: message.emailID ?? message.gmailID
         )
     }
@@ -118,7 +122,7 @@ extension Email {
             threadID: [email.threadID],
             inReplyTo: email.inReplyTo ?? [],
             subject: email.subject,
-            body: nil,
+            body: try? Body(email),
             blobID: email.blobID,
             id: email.id
         )
@@ -185,7 +189,7 @@ extension IMAP.Message {
             gmailThreadID: email.gmailThreadID,
             internalDate: email.received,
             threadID: email.threadID.first,
-            uid: nil
+            uid: email.uid
         )
     }
 }

--- a/Core/Sources/Account/Email.swift
+++ b/Core/Sources/Account/Email.swift
@@ -23,6 +23,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
     public let inReplyTo: [String]
     public let subject: String?
     public let body: Body?
+    public let blobID: String?
 
     public init(
         from: [EmailAddressProtocol] = [],
@@ -38,6 +39,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
         inReplyTo: [String] = [],
         subject: String? = nil,
         body: Body? = nil,
+        blobID: String? = nil,
         id: String? = nil
     ) {
         self.from = from
@@ -53,6 +55,7 @@ public struct Email: CustomStringConvertible, Identifiable, Sendable {
         self.inReplyTo = inReplyTo
         self.subject = subject
         self.body = body
+        self.blobID = blobID
         self.id = id ?? UUID().uuidString(1)
     }
 
@@ -116,6 +119,7 @@ extension Email {
             inReplyTo: email.inReplyTo ?? [],
             subject: email.subject,
             body: nil,
+            blobID: email.blobID,
             id: email.id
         )
     }
@@ -182,6 +186,39 @@ extension IMAP.Message {
             internalDate: email.received,
             threadID: email.threadID.first,
             uid: nil
+        )
+    }
+}
+
+extension JMAP.Email {
+
+    // Map back to JMAP email
+    init(_ email: Email) {
+        self.init(
+            blobID: email.blobID ?? "",
+            threadID: email.threadID.first ?? "",
+            mailboxIDs: [:],  // TODO: JMAP mailbox IDs not carried
+            keywords: [:],  // TODO: JMAP keywords not implemented
+            size: 0,
+            receivedAt: email.received,
+            sentAt: email.sent,
+            messageID: !email.messageID.isEmpty ? email.messageID : nil,
+            inReplyTo: !email.inReplyTo.isEmpty ? email.inReplyTo : nil,
+            references: nil,
+            sender: !email.sender.isEmpty ? email.sender : nil,
+            from: !email.from.isEmpty ? email.from : nil,
+            replyTo: !email.replyTo.isEmpty ? email.replyTo : nil,
+            to: !email.to.isEmpty ? email.to : nil,
+            cc: !email.cc.isEmpty ? email.cc : nil,
+            bcc: !email.bcc.isEmpty ? email.bcc : nil,
+            subject: email.subject,
+            bodyStructure: nil,  // TODO: JMAP body structure encoding not implemented
+            textBody: [],
+            htmlBody: [],
+            attachments: [],  // TODO: JMAP attachments not implemented
+            hasAttachment: false,
+            preview: nil,  // // TODO: JMAP preview not implemented
+            id: email.id
         )
     }
 }

--- a/Core/Sources/Account/EmailManager.swift
+++ b/Core/Sources/Account/EmailManager.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Manage and display a single ``Email`` message for a given ``Account``.
+@Observable
+public final class EmailManager {
+    public let account: Account
+    public private(set) var email: Email?
+    public var error: AccountError?
+
+    public init(_ email: Email?, account: Account) {
+        self.account = account
+        self.email = email
+    }
+
+    public func refreshEmail() async {
+        guard let email else { return }
+        do {
+            switch account.emailProtocol {
+            case .imap:
+                guard let uid: UID = email.uid else {
+                    throw IMAPError.capabilityNotSupported("UID")
+                }
+                let client: IMAPClient = try await account.imapClient
+                let message: Message = try await client.fetch(uid: uid)
+                self.email = Email(message)
+            case .jmap:
+                let client: JMAPClient = try await account.jmapClient
+                let emails: [JMAP.Email] = try await client.emails([email.id])
+                guard !emails.isEmpty else {
+                    throw JMAPError.method(.invalidResultReference)
+                }
+                self.email = Email(emails[0])
+            }
+        } catch {
+            self.error = AccountError(error)
+        }
+    }
+}


### PR DESCRIPTION
## Contribution Summary

PR includes:

- Glue code that completes common `Email` conversion from and _back to_ `IMAP.Message` and `JMAP.Email` 
- Observable `EmailManager` that loads a single, complete email message from IMAP or JMAP

Note that a handful of properties are stubbed nil, pending glue or implementation:

- IMAP flags/Gmail labels/JMAP keywords
- JMAP mailbox tags
- JMAP `BodyStructure` and values
- JMAP attachments

Close #369 

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
