### PR TITLE
feat(UI): Email Composition implementation

### DIFF
--- a/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
@@ -1,0 +1,314 @@
+// ComposeBodyView.swift
+// Thunderbird
+//
+// Created by Logan Klein on 7/2/26.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+
+
+import SwiftUI
+import InfomaniakRichHTMLEditor
+
+struct ComposeBodyView: View {
+    @State private var html = String.sampleHTML
+    @State private var selection = ""
+    @StateObject private var textAttributes = TextAttributes()
+    @FocusState private var keyboardShown: Bool
+
+    var focusBinding: Binding<Bool> {
+        Binding(
+            get: {
+                return keyboardShown
+            },
+            set: { newValue in
+                if newValue == false {
+
+                }
+                keyboardShown = newValue
+            }
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            RichHTMLEditor(html: $html, selection: $selection, textAttributes: textAttributes)
+                .padding()
+                .focused($keyboardShown)
+
+            ComposeToolbar(textAttributes: textAttributes, keyboardShown: focusBinding, selection: $selection)
+                .opacity(keyboardShown ? 1 : 0)
+                .frame(height: keyboardShown ? 44 : 0)
+                .animation(.easeIn(duration: 0.25), value: keyboardShown)
+                .background(.red)
+        }
+    }
+}
+
+#Preview {
+    ComposeBodyView()
+}
+
+extension String {
+    static let sampleHTML = """
+        <!DOCTYPE html>
+        <html>
+
+        <head>
+            <title> TEST HTML PAGE </title>
+            <meta charset="UTF-8">
+            <meta name="description" content="Most of HTML5 tags">
+            <meta name="keywords" content="HTML5, tags">
+            <meta name="author" content="http://blazardsky.space">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+
+        <body>
+            <header>
+                <nav>
+                    <p>HEADER</p>
+                    <menu type="context" id="navmenu">
+                        <menuitem label="Home" icon="icon.png"> <a href="https://www.google.com/">Home</a> </menuitem>
+                    </menu>
+                </nav>
+            </header>
+            <main>
+                <h1> Heading... </h1>
+                <h2> Heading... </h2>
+                <h3> Heading... </h3>
+                <h4> Heading... </h4>
+                <h5> Heading... </h5>
+                <h6> Heading... </h6>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nisi lacus, auctor sit amet purus vel, gravida luctus lectus. Aenean rhoncus dapibus enim, sit amet faucibus leo ornare vitae. <br>
+                    <span> span </span>
+                    <b>Bold word</b>
+                    <i>italic</i>
+                    <em>emphasis</em>
+                    <mark>mark</mark>
+                    <small> small </small>
+                    <sub> sub </sub>
+                    <sup> sup </sup>
+                    <u> Statements... </u>
+                    <abbr title="National Aeronautics and Space Administration">NASA</abbr>
+                    <strike> strikethrough </strike>
+                    <span><del> deprecated info </del> <ins> new info </ins> </span>
+                    <s> not relevant </s>
+                    <a href="#link">link</a>
+                    <time datetime="2020-08-17 08:00">Monday at 8:00 AM</time>
+                    <ruby>
+                        <rb>ruby base<rt>annotation
+                    </ruby>
+                    <br>
+                    <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>CANC</kbd>
+                </p>
+            </main>
+
+            <p> This is a <q>short quote</q> </p>
+            <blockquote> This instead is a long quote that is going to use a lot of words and also cite who said that. —<cite>Some People</cite> </blockquote>
+
+            <ol>
+                <li><data value="21053">data tag</data></li>
+                <li><data value="23452">data tag</data></li>
+                <li><data value="42545">data tag</data></li>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+            </ol>
+
+            <ul>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item</li>
+            </ul>
+
+            <hr>
+
+            <template>
+                <h2>Hidden content (after page loaded).</h2>
+            </template>
+
+            <video width="640" height="480" src="https://archive.org/download/Popeye_forPresident/Popeye_forPresident_512kb.mp4" controls>
+                <track kind="subtitles" src="subtitles_de.vtt" srclang="de">
+                <track kind="subtitles" src="subtitles_en.vtt" srclang="en">
+                <track kind="subtitles" src="subtitles_ja.vtt" srclang="ja">
+                Sorry, your browser doesn't support HTML5 <code>video</code>, but you can
+                download this video from the <a href="https://archive.org/details/Popeye_forPresident" target="_blank">Internet Archive</a>.
+            </video>
+
+            <object data="flashmovie.swf" width="600" height="800" type="application/x-shockwave-flash">
+                Please install the Shockwave plugin to watch this movie.
+            </object>
+
+            <code>
+                // code tag
+                #include <iostream>
+
+                    using namespace std;
+
+                    int main()
+                    {
+                    cout << "Hello World!" << endl; return 0; } </code> <p>
+                        <var> variable </var> = 1000;
+                        <samp>Traceback (most recent call last):<br>NameError: name 'variabl' is not defined</samp>
+                        </p>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Numbers</th>
+                                    <th>Letters</th>
+                                    <th>Colors</th>
+                                </tr>
+                            </thead>
+                            <tfoot>
+                                <tr>
+                                    <td>123</td>
+                                    <td>ABC</td>
+                                    <td>RGB</td>
+                                </tr>
+                            </tfoot>
+                            <tbody>
+                                <tr>
+                                    <td>1</td>
+                                    <td>A</td>
+                                    <td>Red</td>
+                                </tr>
+                                <tr>
+                                    <td>2</td>
+                                    <td>B</td>
+                                    <td>Green</td>
+                                </tr>
+                                <tr>
+                                    <td>3</td>
+                                    <td>C</td>
+                                    <td>Blue</td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <p> A <dfn>definition</dfn> is an explanation of the meaning of a word or phrase. </p>
+
+                        <details>
+                            <summary>Summary of content below</summary>
+                            <p>Content 1</p>
+                            <p>Content 2</p>
+                            <p>Content 3</p>
+                            <p>Content 4</p>
+                        </details>
+                        <section>
+                            <h1>Content</h1>
+                            <p>Informations about content.</p>
+                        </section>
+
+                        <progress value="33" max="100"></progress>
+                        <meter value="11" min="0" max="45" optimum="40">25 out of 45</meter>
+
+                        <p> 2+2 = <output>4</output> </p>
+
+                        <select>
+                            <optgroup label="Choice [1-3]">
+                                <option value="1">One</option>
+                                <option value="2">Two</option>
+                                <option value="3">Three</option>
+                            </optgroup>
+                            <optgroup label="Choice [4-6]">
+                                <option value="4">Four</option>
+                                <option value="5">Five</option>
+                                <option value="6">Six</option>
+                            </optgroup>
+                        </select>
+
+                        <div>
+                            <div>
+                                <p> div > div > p </p>
+                            </div>
+
+                            <br>
+
+
+                        </div>
+                        <svg width="100" height="100">
+                            <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+                        </svg>
+
+                        <br>
+
+                        <textarea id="textarea" name="textarea" rows="4" cols="50">
+                Write something in here
+            </textarea>
+
+                        <br>
+
+                        <audio controls>
+                            I'm sorry. You're browser doesn't support HTML5 <code>audio</code>.
+                            <source src="https://archive.org/download/ReclaimHtml5/ReclaimHtml5.ogg" type="audio/ogg">
+                            <source src="https://archive.org/download/ReclaimHtml5/ReclaimHtml5.mp3" type="audio/mpeg">
+                        </audio>
+                        <p>This is a recording of a talk called <cite>Reclaim HTML5</cite> which was orinally delieved in Vancouver at a <a href="http://www.meetup.com/vancouver-javascript-developers/" taget="_blank">Super VanJS Meetup</a>. It is hosted by <a href="https://archive.org/details/ReclaimHtml5"
+                             target="_blank">The Internet Archive</a> and licensed under <a href="http://creativecommons.org/licenses/by/3.0/legalcode" target="_blank">CC 3.0</a>.</p>
+
+                        <iframe src="https://open.spotify.com/embed?uri=spotify%3Atrack%3A67HxeUADW4H3ERfaPW59ma?si=PogFcGg9QqapyoPbn2lVOw" width="300" height="380" frameborder="0" allowtransparency="true"></iframe>
+
+                        <article>
+                            <header>
+                                <h2>Title of Article</h2>
+                                <span>by Arthur T. Writer</span>
+                            </header>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat sollicitudin nisi, at convallis nunc semper et. Donec ultrices odio ac purus facilisis, at mollis urna finibus.</p>
+                            <figure>
+                                <img src="https://placehold.it/600x300" alt="placeholder-image">
+                                <figcaption> Caption.</figcaption>
+                            </figure>
+                            <footer>
+                                <dl> <dt>Published</dt>
+                                    <dd>17 August 2020</dd> <dt>Tags</dt>
+                                    <dd>Sample Posts, html example</dd>
+                                </dl>
+                            </footer>
+                        </article>
+
+                        <form>
+                            <fieldset>
+                                <legend>Personal Information</legend>
+                                <label for="name">Name</label><br>
+                                <input name="name" id="name"><br>
+                                <label for="dob">Date of Birth<label><br>
+                                        <input name="dob" id="dob" type="date">
+                            </fieldset>
+                        </form>
+
+                        <aside>
+                            <p> P inside ASIDE tag </p>
+                        </aside>
+                        <map name="shapesmap"> <area shape="rect" coords="29,32,230,215" href="#square" alt="Square"> <area shape="circle" coords="360,130,100" href="#circle" alt="Circle"> </map>
+
+                        <img src="https://placehold.it/100x100" alt="placeholder-image">
+
+                        <form action="" method="get">
+                            <label for="browser">Choose your browser from the list:</label>
+                            <input list="browsers" name="browser" id="browser">
+                            <datalist id="browsers">
+                                <option value="Edge">
+                                <option value="Firefox">
+                                <option value="Chrome">
+                                <option value="Opera">
+                                <option value="Safari">
+                            </datalist>
+                            <input type="submit">
+                        </form>
+
+                        <footer>
+                            <address> relevant contacts <a href="mailto:mail@example.com">mail</a>.</address>
+                            <div> created by <a href="https://blazardsky.space">@blazardsky</a></div>
+                        </footer>
+
+        </body>
+
+        </html>
+        """
+}

--- a/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
@@ -33,16 +33,20 @@ struct ComposeBodyView: View {
     }
 
     var body: some View {
-        ZStack {
-            RichHTMLEditor(html: $html, selection: $selection, textAttributes: textAttributes)
-                .padding()
-                .focused($keyboardShown)
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                ComposeHeaderView()
+
+                RichHTMLEditor(html: $html, selection: $selection, textAttributes: textAttributes)
+                    .padding()
+                    .focused($keyboardShown)
+            }
 
             ComposeToolbar(textAttributes: textAttributes, keyboardShown: focusBinding, selection: $selection)
+                .background(.ultraThinMaterial)
                 .opacity(keyboardShown ? 1 : 0)
                 .frame(height: keyboardShown ? 44 : 0)
                 .animation(.easeIn(duration: 0.25), value: keyboardShown)
-                .background(.red)
         }
     }
 }

--- a/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeBodyView.swift
@@ -1,13 +1,6 @@
-// ComposeBodyView.swift
-// Thunderbird
-//
-// Created by Logan Klein on 7/2/26.
-//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-
 
 import SwiftUI
 import InfomaniakRichHTMLEditor

--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -1,9 +1,6 @@
-//
-//  ComposeHeaderView.swift
-//  Thunderbird
-//
-//  Created by Ashley Soucar on 2/18/26.
-//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 import Account
@@ -77,7 +74,7 @@ struct ComposeHeaderView: View {
             TextField("subject_header", text: $subject)
                 .font(.subheadline)
                 .padding()
-                .background(.gray, in: RoundedRectangle(cornerRadius:24))
+                .background(.gray, in: RoundedRectangle(cornerRadius: 24))
         }
         .padding()
     }
@@ -120,7 +117,7 @@ struct MultiAddressBar: View {
             }
         }
         .padding()
-        .background(.gray, in: RoundedRectangle(cornerRadius:24))
+        .background(.gray, in: RoundedRectangle(cornerRadius: 24))
     }
 }
 

--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -22,54 +22,64 @@ struct ComposeHeaderView: View {
 
     var body: some View {
         VStack {
-            List {
-                Section {
-                    HStack {
-                        Picker("from_header", selection: $selectedSender) {
-                            ForEach(accounts.allAccounts) { account in
-                                Text(account.name).tag(account.id)
-                            }
-                        } currentValueLabel: {
-                            Text(accounts.account(for: selectedSender)?.name ?? "")
+            Group {
+                HStack {
+                    Picker("from_header", selection: $selectedSender) {
+                        ForEach(accounts.allAccounts) { account in
+                            Text(account.name).tag(account.id)
                         }
-                        .pickerStyle(.menu)
+                    } currentValueLabel: {
+                        Text(accounts.account(for: selectedSender)?.name ?? "")
+                    }
+                    .pickerStyle(.menu)
 
-                        Spacer()
+                    Spacer()
 
+                    VStack {
                         if !showReplyTo {
+                            Spacer()
                             Button("", systemImage: "chevron.down") {
                                 showReplyTo = true
                             }
                             .foregroundStyle(.black)
+                            Spacer()
                         }
                     }
+                }
 
-                    if showReplyTo {
-                        MultiAddressBar("reply_to_header", $replyToRecipients)
-                    }
+                if showReplyTo {
+                    MultiAddressBar("reply_to_header", $replyToRecipients)
+                }
 
-                    HStack(alignment: .top) {
-                        MultiAddressBar("to_header", $toRecipients)
-                        if !showCCBCC {
+                HStack(alignment: .top) {
+                    MultiAddressBar("to_header", $toRecipients)
+                    if !showCCBCC {
+                        VStack {
+                            Spacer()
                             Button("", systemImage: "chevron.down") {
                                 showCCBCC = true
                             }
                             .foregroundStyle(.black)
+                            Spacer()
                         }
                     }
-
-                    if showCCBCC {
-                        MultiAddressBar("cc_header", $ccRecipients)
-                        MultiAddressBar("bcc_header", $bccRecipients)
-                    }
-
-                    TextField("subject_header", text: $subject)
                 }
             }
-            .frame(alignment: .leading)
-            .font(.subheadline)
-            .scrollDisabled(true)
+            .padding(.bottom, 4)
+
+            if showCCBCC {
+                MultiAddressBar("cc_header", $ccRecipients)
+                MultiAddressBar("bcc_header", $bccRecipients)
+            }
+
+            Divider()
+
+            TextField("subject_header", text: $subject)
+                .font(.subheadline)
+                .padding()
+                .background(.gray, in: RoundedRectangle(cornerRadius:24))
         }
+        .padding()
     }
 }
 
@@ -92,7 +102,7 @@ struct MultiAddressBar: View {
                 Text(headerText)
                     .fixedSize()
                 TextField("", text: $entryString)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(.automatic)
                     .autocorrectionDisabled()
                     .autocapitalization(.none)
                     .focusable()
@@ -109,7 +119,8 @@ struct MultiAddressBar: View {
                 }
             }
         }
-
+        .padding()
+        .background(.gray, in: RoundedRectangle(cornerRadius:24))
     }
 }
 

--- a/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeHeaderView.swift
@@ -23,40 +23,52 @@ struct ComposeHeaderView: View {
     var body: some View {
         VStack {
             List {
-                HStack {
-                    Picker("from_header", selection: $selectedSender) {
-                        ForEach(accounts.allAccounts) { account in
-                            Text(account.name).tag(account.id)
+                Section {
+                    HStack {
+                        Picker("from_header", selection: $selectedSender) {
+                            ForEach(accounts.allAccounts) { account in
+                                Text(account.name).tag(account.id)
+                            }
+                        } currentValueLabel: {
+                            Text(accounts.account(for: selectedSender)?.name ?? "")
                         }
-                    } currentValueLabel: {
-                        Text(accounts.account(for: selectedSender)?.name ?? "")
-                    }.pickerStyle(.menu)
-                    Spacer()
-                    if !showReplyTo {
-                        Button("", systemImage: "chevron.down") {
-                            showReplyTo = true
-                        }.foregroundStyle(.black)
-                    }
-                }
-                if showReplyTo {
-                    MultiAddressBar("reply_to_header", $replyToRecipients)
-                }
-                HStack(alignment: .top) {
-                    MultiAddressBar("to_header", $toRecipients)
-                    if !showCCBCC {
-                        Button("", systemImage: "chevron.down") {
-                            showCCBCC = true
-                        }.foregroundStyle(.black)
-                    }
-                }
-                if showCCBCC {
-                    MultiAddressBar("cc_header", $ccRecipients)
-                    MultiAddressBar("bcc_header", $bccRecipients)
-                }
+                        .pickerStyle(.menu)
 
-                TextField("subject_header", text: $subject)
-            }.frame(alignment: .leading)
-                .font(.subheadline)
+                        Spacer()
+
+                        if !showReplyTo {
+                            Button("", systemImage: "chevron.down") {
+                                showReplyTo = true
+                            }
+                            .foregroundStyle(.black)
+                        }
+                    }
+
+                    if showReplyTo {
+                        MultiAddressBar("reply_to_header", $replyToRecipients)
+                    }
+
+                    HStack(alignment: .top) {
+                        MultiAddressBar("to_header", $toRecipients)
+                        if !showCCBCC {
+                            Button("", systemImage: "chevron.down") {
+                                showCCBCC = true
+                            }
+                            .foregroundStyle(.black)
+                        }
+                    }
+
+                    if showCCBCC {
+                        MultiAddressBar("cc_header", $ccRecipients)
+                        MultiAddressBar("bcc_header", $bccRecipients)
+                    }
+
+                    TextField("subject_header", text: $subject)
+                }
+            }
+            .frame(alignment: .leading)
+            .font(.subheadline)
+            .scrollDisabled(true)
         }
     }
 }

--- a/Thunderbird/Thunderbird/ComposeView/ComposeToolbar.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeToolbar.swift
@@ -1,0 +1,194 @@
+// ComposeToolbar.swift
+// Thunderbird
+//
+// Created by Logan Klein on 7/2/26.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+
+
+import SwiftUI
+import InfomaniakRichHTMLEditor
+
+struct ComposeToolbar: View {
+    @ObservedObject var textAttributes: TextAttributes
+    @State private var isShowingLinkAlert: Bool = false
+    @State private var linkText: String = ""
+    @State private var linkUrl: String = "https://www.google.com"
+    @Binding var keyboardShown: Bool
+    @Binding var selection: String
+
+    var body: some View {
+        // Inline bindings allow us to leave the properties as private (set)
+        // within `TextAttributes`, and still respond to events.
+        let foregroundColor = Binding<Color>(
+            get: { textAttributes.foregroundColor ?? .black },
+            set: { newValue in
+                textAttributes.setForegroundColor(UIColor(newValue))
+            }
+        )
+
+        let backgroundColor = Binding<Color>(
+            get: { textAttributes.backgroundColor ?? .white },
+            set: { newValue in
+                textAttributes.setBackgroundColor(UIColor(newValue))
+            }
+        )
+
+        ScrollView(.horizontal) {
+            Divider()
+
+            HStack(spacing: 4) {
+                EditorToolbarButton(systemImage: "keyboard.chevron.compact.down", isActive: false) {
+                    keyboardShown.toggle()
+                }
+
+                ColorPicker("", selection: foregroundColor, supportsOpacity: false)
+                    .labelsHidden()
+                    .padding(.leading, 8)
+                    // Opacity below .02 seems to disable hit testing for the picker.
+                    .opacity(0.02)
+                    .overlay {
+                        Image(systemName: "character.square")
+                            .foregroundStyle(textAttributes.foregroundColor ?? .black)
+                            // Additional padding is needed to center the overlay image
+                            // within the color picker area.
+                            .padding(.leading, 8)
+                            .allowsHitTesting(false)
+                    }
+
+                ColorPicker("", selection: backgroundColor, supportsOpacity: false)
+                    .labelsHidden()
+                    .padding(.leading, 8)
+                    .opacity(0.02)
+                    .overlay {
+                        ZStack {
+                            Circle()
+                                .frame(width: 24, height: 24)
+                                .foregroundStyle(textAttributes.backgroundColor ?? .white)
+                            Image(systemName: "character.square")
+                                .foregroundStyle(textAttributes.foregroundColor ?? .black)
+                        }
+                        .allowsHitTesting(false)
+                        .padding(.leading, 8)
+                    }
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "link", isActive: textAttributes.hasLink) {
+                    clearLinkInfo()
+
+                    // Assign the default link text to the selected text in the editor.
+                    linkText = selection
+                    // Remove focus from the webview editor so that focus can be assigned to the alert view text fields.
+                    keyboardShown = false
+                    // Display the alert to assign link information.
+                    isShowingLinkAlert = true
+                }
+                .alert("Add a link", isPresented: $isShowingLinkAlert) {
+                    TextField("Text", text: $linkText)
+
+                    TextField("URL", text: $linkUrl)
+
+                    Button("Submit") {
+                        if linkText.isEmpty || linkUrl.isEmpty {
+                            textAttributes.unlink()
+                            keyboardShown = true
+                        } else if let url = URL(string: linkUrl) {
+                            keyboardShown = true
+                            textAttributes.addLink(url: url, text: linkText)
+                        } else {
+                            // TODO: Display a warning message here.
+                            print("error adding link")
+                        }
+                    }
+
+                    Button("Cancel", role: .cancel) {
+                        if linkText.isEmpty || linkUrl.isEmpty {
+                            keyboardShown = true
+                        }
+                    }
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "bold", isActive: textAttributes.hasBold) {
+                    textAttributes.bold()
+                }
+                EditorToolbarButton(systemImage: "italic", isActive: textAttributes.hasItalic) {
+                    textAttributes.italic()
+                }
+                EditorToolbarButton(systemImage: "underline", isActive: textAttributes.hasUnderline) {
+                    textAttributes.underline()
+                }
+                EditorToolbarButton(systemImage: "strikethrough", isActive: textAttributes.hasStrikethrough) {
+                    textAttributes.strikethrough()
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "list.number", isActive: textAttributes.hasOrderedList) {
+                    textAttributes.orderedList()
+                }
+                EditorToolbarButton(systemImage: "list.bullet", isActive: textAttributes.hasUnorderedList) {
+                    textAttributes.unorderedList()
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "decrease.indent", isActive: false) {
+                    textAttributes.outdent()
+                }
+                EditorToolbarButton(systemImage: "increase.indent", isActive: false) {
+                    textAttributes.indent()
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "arrow.uturn.backward", isActive: false) {
+                    textAttributes.undo()
+                }
+                EditorToolbarButton(systemImage: "arrow.uturn.forward", isActive: false) {
+                    textAttributes.redo()
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: 44)
+    }
+
+    func clearLinkInfo() {
+        linkText = ""
+        linkUrl = ""
+    }
+}
+
+struct EditorToolbarButton: View {
+    let systemImage: String
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.body)
+                .frame(width: 36, height: 36)
+                .foregroundStyle(isActive ? Color.accentColor : .primary)
+                .background(isActive ? Color.accentColor.opacity(0.2) : .clear, in: .rect(cornerRadius: 12))
+        }
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var textAttributes = TextAttributes()
+    @Previewable @State var keyboardShown = false
+    @Previewable @State var selection = ""
+    ComposeToolbar(textAttributes: textAttributes, keyboardShown: $keyboardShown, selection: $selection)
+}

--- a/Thunderbird/Thunderbird/ComposeView/ComposeToolbar.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeToolbar.swift
@@ -1,13 +1,6 @@
-// ComposeToolbar.swift
-// Thunderbird
-//
-// Created by Logan Klein on 7/2/26.
-//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-
 
 import SwiftUI
 import InfomaniakRichHTMLEditor

--- a/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
@@ -12,9 +12,9 @@ struct ComposeView: View {
     @State private var rawText = NSAttributedString(string: "")
 
     var body: some View {
-        VStack {
+        ScrollView {
             ComposeHeaderView()
-
+            ComposeBodyView()
         }.toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
@@ -24,6 +24,5 @@ struct ComposeView: View {
                 }
             }
         }
-
     }
 }

--- a/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
@@ -12,10 +12,8 @@ struct ComposeView: View {
     @State private var rawText = NSAttributedString(string: "")
 
     var body: some View {
-        ScrollView {
-            ComposeHeaderView()
-            ComposeBodyView()
-        }.toolbar {
+        ComposeBodyView()
+        .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
                 }) {

--- a/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
@@ -1,9 +1,6 @@
-//
-//  ComposeView.swift
-//  Thunderbird
-//
-//  Created by Ashley Soucar on 2/18/26.
-//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
 
@@ -13,14 +10,15 @@ struct ComposeView: View {
 
     var body: some View {
         ComposeBodyView()
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {
-                }) {
-                    Image(systemName: "archivebox")
-                        .foregroundStyle(.foreground)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+
+                    }) {
+                        Image(systemName: "archivebox")
+                            .foregroundStyle(.foreground)
+                    }
                 }
             }
-        }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Pull requests may take a few days to weeks to review. We’re a small team and prioritize contributions aligned with our [current roadmap](https://roadmaps.thunderbird.net/en-US/ios). 
> You can help us by categorizing your pull request with labels. 
> We appreciate you working with us and will get to reviewing your contribution as soon as we can!

## Contribution Summary
* Adds a view for the display and editing of HTML email bodies.
* Adds a toolbar view containing controls for editing HTML elements.

The `ComposeView` now displays the `ComposeBodyView` directly, which contains the `ComposeHeaderView`. This is to maintain access to the toolbar on screen without having to bridge to a UIKit view which is then attached to the `RichHTMLEditor` via the `editorInputAccessoryView`, as this creates view conflicts when interacting with `ColorPicker` elements. Additionally the elements within the `ComposeHeaderView` have been moved out of a `List`, because a `List` cannot be displayed within a `ScrollView` without significant display issues. As design moves forward, we may end up folding the email composition view into a `List` element directly, but I find it more likely that our final design of the composition headers will likely involve more customized elements.

### NOTE
Because the elements of the email header fields and the editor toolbar are likely to change, these have been left in an incomplete design stage. Further input from the design team will be needed before this is ready for go live review.

## Screenshots
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 03 35" src="https://github.com/user-attachments/assets/a7861d0a-9260-4dec-9781-8d73a5c17ccc"/>
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 03 47" src="https://github.com/user-attachments/assets/08285020-4038-458f-b931-39a50c898b58" />
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 04 09" src="https://github.com/user-attachments/assets/854bcf96-6e5e-4d4c-b807-8d50c6cb9c66" />
<img width="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 04 27" src="https://github.com/user-attachments/assets/2c9c735b-c30a-4c0b-9cc0-0d7f40b8be11" />


## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
