### PR TITLE
Editability flag usage for email composition view

### DIFF
--- a/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
+++ b/Thunderbird/Thunderbird/ComposeView/ComposeView.swift
@@ -9,7 +9,7 @@ struct ComposeView: View {
     @State private var rawText = NSAttributedString(string: "")
 
     var body: some View {
-        ComposeBodyView()
+        EmailBodyView(editable: true)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: {

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
@@ -5,11 +5,14 @@
 import SwiftUI
 import InfomaniakRichHTMLEditor
 
-struct ComposeBodyView: View {
+struct EmailBodyView: View {
+    @Environment(\.openURL) var openURL
+
     @State private var html = String.sampleHTML
     @State private var selection = ""
     @StateObject private var textAttributes = TextAttributes()
     @FocusState private var keyboardShown: Bool
+    let editable: Bool
 
     var focusBinding: Binding<Bool> {
         Binding(
@@ -17,10 +20,9 @@ struct ComposeBodyView: View {
                 return keyboardShown
             },
             set: { newValue in
-                if newValue == false {
-
+                if newValue == true && editable {
+                    keyboardShown = newValue
                 }
-                keyboardShown = newValue
             }
         )
     }
@@ -30,22 +32,35 @@ struct ComposeBodyView: View {
             ScrollView {
                 ComposeHeaderView()
 
-                RichHTMLEditor(html: $html, selection: $selection, textAttributes: textAttributes)
-                    .padding()
-                    .focused($keyboardShown)
+                RichHTMLEditor(html: $html,
+                               selection: $selection,
+                               editable: editable,
+                               textAttributes: textAttributes)
+                .handleLinkOpening(perform: { URL in
+                    Task { @MainActor in
+                        // This results in intermittent crashing when tapping on links, even when run on the main thread. There is significantly increased stability by using the `prefersInApp` option available in iOS 26 and later.
+                        openURL(URL)
+//                        openURL(URL, prefersInApp: true)
+                    }
+                    return true
+                })
+                .padding()
+                .focused($keyboardShown)
             }
 
-            ComposeToolbar(textAttributes: textAttributes, keyboardShown: focusBinding, selection: $selection)
-                .background(.ultraThinMaterial)
-                .opacity(keyboardShown ? 1 : 0)
-                .frame(height: keyboardShown ? 44 : 0)
-                .animation(.easeIn(duration: 0.25), value: keyboardShown)
+            if editable {
+                ComposeToolbar(textAttributes: textAttributes, keyboardShown: focusBinding, selection: $selection)
+                    .background(.ultraThinMaterial)
+                    .opacity(keyboardShown ? 1 : 0)
+                    .frame(height: keyboardShown ? 44 : 0)
+                    .animation(.easeIn(duration: 0.25), value: keyboardShown)
+            }
         }
     }
 }
 
 #Preview {
-    ComposeBodyView()
+    EmailBodyView(editable: false)
 }
 
 extension String {

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
@@ -32,20 +32,17 @@ struct EmailBodyView: View {
             ScrollView {
                 ComposeHeaderView()
 
-                RichHTMLEditor(html: $html,
-                               selection: $selection,
-                               editable: editable,
-                               textAttributes: textAttributes)
-                .handleLinkOpening(perform: { URL in
-                    Task { @MainActor in
-                        // This results in intermittent crashing when tapping on links, even when run on the main thread. There is significantly increased stability by using the `prefersInApp` option available in iOS 26 and later.
-                        openURL(URL)
-//                        openURL(URL, prefersInApp: true)
-                    }
-                    return true
-                })
-                .padding()
-                .focused($keyboardShown)
+                RichHTMLEditor(html: $html, selection: $selection, editable: editable, textAttributes: textAttributes)
+                    .handleLinkOpening(perform: { URL in
+                        Task { @MainActor in
+                            // This results in intermittent crashing when tapping on links, even when run on the main thread. There is significantly increased stability by using the `prefersInApp` option available in iOS 26 and later.
+                            openURL(URL)
+//                            openURL(URL, prefersInApp: true)
+                        }
+                        return true
+                    })
+                    .padding()
+                    .focused($keyboardShown)
             }
 
             if editable {

--- a/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
+++ b/Thunderbird/Thunderbird/EmailDisplay/EmailBodyView.swift
@@ -37,7 +37,6 @@ struct EmailBodyView: View {
                         Task { @MainActor in
                             // This results in intermittent crashing when tapping on links, even when run on the main thread. There is significantly increased stability by using the `prefersInApp` option available in iOS 26 and later.
                             openURL(URL)
-//                            openURL(URL, prefersInApp: true)
                         }
                         return true
                     })


### PR DESCRIPTION
> [!IMPORTANT]
> Pull requests may take a few days to weeks to review. We’re a small team and prioritize contributions aligned with our [current roadmap](https://roadmaps.thunderbird.net/en-US/ios). 
> You can help us by categorizing your pull request with labels. 
> We appreciate you working with us and will get to reviewing your contribution as soon as we can!

## Contribution Summary
Includes the updates to the rich HTML editor library and refactors the email composition view to a more generic display view which can be configured to be editable with a parameter.

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).