### PR TITLE
OAuth2 Token and Refresh Token retrieval and storage

### DIFF
--- a/Core/Sources/Account/AccountManager.swift
+++ b/Core/Sources/Account/AccountManager.swift
@@ -33,6 +33,7 @@ public final class AccountManager {
             } else {
                 accounts.append(account)  // Append to end of array
             }
+            allAccounts = accounts
             try FileManager.default.write(accounts, to: .accounts)
             allAccounts = try FileManager.default.readAccounts(from: .accounts)
         } catch {

--- a/Core/Sources/Account/Authorization.swift
+++ b/Core/Sources/Account/Authorization.swift
@@ -30,7 +30,7 @@ public enum Authorization: CustomStringConvertible, Equatable {
     var password: String {
         switch self {
         case .basic(let user, let password): return "\(user.components(separatedBy: " ")[0]):\(password)".data(using: .utf8)!.base64EncodedString()
-        case .oauth(_, let token, let refreshToken):
+        case .oauth(_, let token, _):
             return "\(token.description)"
 
         case .none: return ""

--- a/Core/Sources/Account/Authorization.swift
+++ b/Core/Sources/Account/Authorization.swift
@@ -31,8 +31,7 @@ public enum Authorization: CustomStringConvertible, Equatable {
         switch self {
         case .basic(let user, let password): return "\(user.components(separatedBy: " ")[0]):\(password)".data(using: .utf8)!.base64EncodedString()
         case .oauth(_, let token, let refreshToken):
-            let passwordString = "\(token.description):\(token.tokenExpiration?.timeIntervalSince1970, default: "0"):\(refreshToken.description)"
-            return passwordString.data(using: .utf8)!.base64EncodedString()
+            return "\(token.description)"
 
         case .none: return ""
         }
@@ -49,7 +48,11 @@ public enum Authorization: CustomStringConvertible, Equatable {
     /// Derive appropriate authorization case from naked `URLCredential` user/password strings.
     init(user: String, password: String?) {
         let password: String = password ?? ""
-        let data: Data = Data(base64Encoded: password)!
+        let data: Data? = Data(base64Encoded: password)
+        guard let data else {
+            self = .none
+            return
+        }
         if let components: [String] = String(data: data, encoding: .utf8)?.components(separatedBy: ":"),
             components.count == 2, components.first == user.components(separatedBy: " ")[0]
         {

--- a/Core/Sources/Account/Authorization.swift
+++ b/Core/Sources/Account/Authorization.swift
@@ -7,12 +7,12 @@ import Foundation
 /// Authorization credential  for a given user name, either an OAuth token or basic password
 public enum Authorization: CustomStringConvertible, Equatable {
     case basic(user: String, password: String)
-    case oauth(user: String, token: Token)
+    case oauth(user: String, token: Token, refresh: Token)
     case none
 
     public var user: String {
         switch self {
-        case .basic(let user, _), .oauth(let user, _): user
+        case .basic(let user, _), .oauth(let user, _, _): user
         case .none: ""
         }
     }
@@ -29,22 +29,40 @@ public enum Authorization: CustomStringConvertible, Equatable {
     /// Encoded `URLCredential` password value (for keychain storage)
     var password: String {
         switch self {
-        case .basic(let user, let password): "\(user.components(separatedBy: " ")[0]):\(password)".data(using: .utf8)!.base64EncodedString()
-        case .oauth(_, let token): token.description
-        case .none: ""
+        case .basic(let user, let password): return "\(user.components(separatedBy: " ")[0]):\(password)".data(using: .utf8)!.base64EncodedString()
+        case .oauth(_, let token, let refreshToken):
+            let passwordString = "\(token.description):\(token.tokenExpiration?.timeIntervalSince1970, default: "0"):\(refreshToken.description)"
+            return passwordString.data(using: .utf8)!.base64EncodedString()
+
+        case .none: return ""
+        }
+    }
+
+    var isExpired: Bool {
+        switch self {
+        case .basic(_, _): return false
+        case .oauth(_, let token, _): return token.isExpired
+        case .none: return false
         }
     }
 
     /// Derive appropriate authorization case from naked `URLCredential` user/password strings.
     init(user: String, password: String?) {
         let password: String = password ?? ""
-        if let data: Data = Data(base64Encoded: password),
-            let components: [String] = String(data: data, encoding: .utf8)?.components(separatedBy: ":"),
+        let data: Data = Data(base64Encoded: password)!
+        if let components: [String] = String(data: data, encoding: .utf8)?.components(separatedBy: ":"),
             components.count == 2, components.first == user.components(separatedBy: " ")[0]
         {
             self = .basic(user: user, password: components.last!)
         } else {
-            self = .oauth(user: user, token: .bearer(password))
+            if let components: [String] = String(data: data, encoding: .utf8)?.components(separatedBy: ":"),
+                components.count == 3
+            {
+                let expDate = Date(timeIntervalSince1970: TimeInterval(components[1]) ?? 0)
+                self = .oauth(user: user, token: .bearer(components.first!, expDate), refresh: .refresh(components.last!))
+            } else {
+                self = .none
+            }
         }
     }
 

--- a/Core/Sources/Account/Server.swift
+++ b/Core/Sources/Account/Server.swift
@@ -192,7 +192,7 @@ private extension Authorization {
     var rawValue: String {
         switch self {
         case .basic(_, let password): password
-        case .oauth(_, let token): token.value
+        case .oauth(_, let token, _): token.value
         case .none: ""
         }
     }

--- a/Core/Sources/Account/Token.swift
+++ b/Core/Sources/Account/Token.swift
@@ -4,20 +4,39 @@
 
 import Foundation
 
-public enum Token: CustomStringConvertible, Equatable, ExpressibleByStringLiteral {
-    case bearer(String)
+public enum Token: CustomStringConvertible, Equatable {
+    case bearer(String, Date)
+    case refresh(String)
 
     var value: String {
         switch self {
-        case .bearer(let token): token
+        case .bearer(let token, _): token
+        case .refresh(let token): token
+        }
+    }
+
+    var isExpired: Bool {
+        switch self {
+        case .bearer(_, let expiration): return Date() > expiration
+        case .refresh(_): return false
+        }
+    }
+
+    var tokenExpiration: Date? {
+        switch self {
+        case .bearer(_, let expiration): return expiration
+        case .refresh(_): return nil
         }
     }
 
     // MARK: CustomStringConvertible
     public var description: String { value }
 
-    // MARK: ExpressibleByStringLiteral
-    public init(stringLiteral value: String) {
-        self = .bearer(value)
+    public init(value: String, expiration: Date) {
+        self = .bearer(value, expiration)
+    }
+
+    public init(value: String) {
+        self = .refresh(value)
     }
 }

--- a/Core/Sources/Autoconfiguration/OAuth2.swift
+++ b/Core/Sources/Autoconfiguration/OAuth2.swift
@@ -40,6 +40,18 @@ public struct OAuth2: Decodable {
             return components.url!
         }
 
+        public func refreshTokenURL(_ refreshToken: String) -> URL {
+            var components: URLComponents = URLComponents(string: tokenURI)!  // Validated during init
+            components.queryItems = [
+                URLQueryItem(name: "client_id", value: clientID),
+                URLQueryItem(name: "client_secret", value: ""),
+                URLQueryItem(name: "redirect_uri", value: redirectURI),
+                URLQueryItem(name: "grant_type", value: "refresh_token"),
+                URLQueryItem(name: "refresh_token", value: refreshToken)
+            ]
+            return components.url!
+        }
+
         public func matches(_ host: String) -> Bool {
             for _host in hosts {
                 guard host.hasSuffix(_host) else { continue }

--- a/Core/Sources/Autoconfiguration/TokenResponse.swift
+++ b/Core/Sources/Autoconfiguration/TokenResponse.swift
@@ -8,8 +8,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 //
 
-public struct TokenResponse: Codable {
-    public let access_token: String
-    public let expires_in: Int
-    public let refresh_token: String
+public struct TokenResponse: Decodable {
+    public let accessToken: String
+    public let expiresIn: Int
+    public let refreshToken: String
+
+    // MARK: Decodable
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        expiresIn = try container.decode(Int.self, forKey: .expiresIn)
+        refreshToken = try container.decode(String.self, forKey: .refreshToken)
+    }
+
+    private enum Key: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
 }

--- a/Core/Sources/Autoconfiguration/TokenResponse.swift
+++ b/Core/Sources/Autoconfiguration/TokenResponse.swift
@@ -1,0 +1,15 @@
+// TokenResponse.swift
+// Core
+//
+// Created by Ashley Soucar on 8/4/26.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+
+public struct TokenResponse: Codable {
+    public let access_token: String
+    public let expires_in: Int
+    public let refresh_token: String
+}

--- a/Core/Sources/Autoconfiguration/URLRequest.swift
+++ b/Core/Sources/Autoconfiguration/URLRequest.swift
@@ -20,4 +20,20 @@ extension URLRequest {
         request.httpBody = httpBody
         return request
     }
+
+    public static func refreshToken(_ request: OAuth2.Request, refreshToken: String) throws -> Self {
+        guard
+            var components: URLComponents = URLComponents(
+                url: request.refreshTokenURL(refreshToken),
+                resolvingAgainstBaseURL: false
+            ), let httpBody: Data = components.percentEncodedQuery?.data(using: .utf8)
+        else {
+            throw URLError(.badURL)
+        }
+        components.queryItems = nil
+        var request: Self = Self(url: components.url!)
+        request.httpMethod = "POST"
+        request.httpBody = httpBody
+        return request
+    }
 }

--- a/Core/Tests/AccountTests/AuthorizationTests.swift
+++ b/Core/Tests/AccountTests/AuthorizationTests.swift
@@ -7,26 +7,60 @@ import Testing
 import Foundation
 
 struct AuthorizationTests {
+    let testExpirDate = Date(timeIntervalSince1970: 0)
     @Test func user() {
         #expect(Authorization.basic(user: "user@example.com IMAP:E621E1F8", password: "").user == "user@example.com IMAP:E621E1F8")
-        #expect(Authorization.oauth(user: "user@example.com IMAP:E621E1F8", token: "").user == "user@example.com IMAP:E621E1F8")
+        #expect(
+            Authorization
+                .oauth(
+                    user: "user@example.com IMAP:E621E1F8",
+                    token:
+                        .bearer("fmu1-1e911257e86b1f194daa-0-a89faae5c11f", testExpirDate),
+                    refresh: .refresh("fakeRefreshToken")
+                ).user == "user@example.com IMAP:E621E1F8"
+        )
         #expect(Authorization.none.user == "")
     }
 
     @Test func value() {
         #expect(Authorization.basic(user: "user@example.com IMAP:E621E1F8", password: "P@$sW0rd!").value == "Basic dXNlckBleGFtcGxlLmNvbTpQQCRzVzByZCE=")
-        #expect(Authorization.oauth(user: "user@example.com IMAP:E621E1F8", token: "fmu1-1e911257e86b1f194daa-0-a89faae5c11f").value == "Bearer fmu1-1e911257e86b1f194daa-0-a89faae5c11f")
+        #expect(
+            Authorization
+                .oauth(
+                    user: "user@example.com IMAP:E621E1F8",
+                    token: .bearer("fmu1-1e911257e86b1f194daa-0-a89faae5c11f", testExpirDate),
+                    refresh: .refresh("fakeRefreshToken")
+                ).value == "Bearer fmu1-1e911257e86b1f194daa-0-a89faae5c11f"
+        )
         #expect(Authorization.none.value == "")
     }
 
     @Test func password() {
         #expect(Authorization.basic(user: "user@example.com IMAP:E621E1F8", password: "P@$sW0rd!").password == "dXNlckBleGFtcGxlLmNvbTpQQCRzVzByZCE=")
-        #expect(Authorization.oauth(user: "user@example.com IMAP:E621E1F8", token: "fmu1-1e911257e86b1f194daa-0-a89faae5c11f").password == "fmu1-1e911257e86b1f194daa-0-a89faae5c11f")
+        #expect(
+            Authorization
+                .oauth(
+                    user: "user@example.com IMAP:E621E1F8",
+                    token:
+                        .bearer("fmu1-1e911257e86b1f194daa-0-a89faae5c11f", testExpirDate),
+                    refresh: .refresh("fakeRefreshToken")
+                ).password == "fmu1-1e911257e86b1f194daa-0-a89faae5c11f"
+        )
         #expect(Authorization.none.password == "")
     }
 
     @Test func userInit() {
         #expect(Authorization(user: "user@example.com IMAP:E621E1F8", password: "dXNlckBleGFtcGxlLmNvbTpQQCRzVzByZCE=") == .basic(user: "user@example.com IMAP:E621E1F8", password: "P@$sW0rd!"))
-        #expect(Authorization(user: "user@example.com IMAP:E621E1F8", password: "fmu1-1e911257e86b1f194daa-0-a89faae5c11f") == .oauth(user: "user@example.com IMAP:E621E1F8", token: "fmu1-1e911257e86b1f194daa-0-a89faae5c11f"))
+        #expect(
+            Authorization(user: "user@example.com IMAP:E621E1F8", password: "Zm11MS0xZTkxMTI1N2U4NmIxZjE5NGRhYS0wLWE4OWZhYWU1YzExZjowLjA6ZmFrZVJlZnJlc2hUb2tlbg==")
+                == .oauth(
+                    user: "user@example.com IMAP:E621E1F8",
+                    token: .bearer(
+                        "fmu1-1e911257e86b1f194daa-0-a89faae5c11f",
+                        testExpirDate
+                    ),
+                    refresh: .refresh("fakeRefreshToken")
+                )
+        )
     }
 }

--- a/Core/Tests/AccountTests/ServerTests.swift
+++ b/Core/Tests/AccountTests/ServerTests.swift
@@ -24,15 +24,21 @@ struct ServerTests {
             hostname: "imap.example.com"
         )
         #expect(server.authorization == .none)
-        server.authorization = .oauth(user: "user@example.com", token: "zemhu8-omdRiz-zisbov")
+        server.authorization =
+            .oauth(
+                user: "user@example.com",
+                token: .bearer("zemhu8-omdRiz-zisbov", Date()),
+                refresh: .refresh("fakeRefreshToken")
+            )
         #expect(server.user == "user@example.com IMAP:\(server.id.uuidString.components(separatedBy: "-")[0])")
         #expect(URLCredentialStorage.shared.authorization(for: server.user) != nil)
         #expect(server.authorization.user == "user@example.com")
         #expect(server.authorization.password == "zemhu8-omdRiz-zisbov")
         switch server.authorization {
-        case .oauth(let user, let token):
+        case .oauth(let user, let token, let refresh):
             #expect(user == "user@example.com")
-            #expect(token == "zemhu8-omdRiz-zisbov")
+            #expect(token.value == "zemhu8-omdRiz-zisbov")
+            #expect(refresh.value == "fakeRefreshToken")
         default:
             throw URLError(.redirectToNonExistentLocation)
         }

--- a/Core/Tests/AccountTests/URLCredentialStorageTests.swift
+++ b/Core/Tests/AccountTests/URLCredentialStorageTests.swift
@@ -28,15 +28,23 @@ struct URLCredentialStorageTests {
                 authorization:
                     .oauth(
                         user: "user.name@gmail.com",
-                        token: Token(value: "zemhu8-omdRiz-zisbov"),
-                        refresh: Token(value: "zemhu8-omdRiz-zisbov")
+                        token: .bearer("zemhu8-omdRiz-zisbov", Date()),
+                        refresh: .refresh("zemhu8-omdRiz-zisbov-refresh")
                     ),
                 space: space
             )  // Duplicate user
         #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 1)  // One credential stored per user
         #expect(URLCredentialStorage.shared.authorization(for: "user.name@gmail.com", space: space)?.password == "zemhu8-omdRiz-zisbov")
         URLCredentialStorage.shared
-            .set(authorization: .oauth(user: "user.name@gmail.com", token: Token(value: "zemhu8-omdRiz-zisbov"), refresh: Token(value: "zemhu8-omdRiz-zisbov")), space: space)
+            .set(
+                authorization:
+                    .oauth(
+                        user: "user.name@gmail.com",
+                        token: .bearer("zemhu8-omdRiz-zisbov", Date()),
+                        refresh: .refresh("zemhu8-omdRiz-zisbov-refresh")
+                    ),
+                space: space
+            )
         #expect(URLCredentialStorage.shared.credentials(for: space) == nil)
     }
 
@@ -64,7 +72,12 @@ struct URLCredentialStorageTests {
             )  // Duplicate credential
         URLCredentialStorage.shared
             .set(
-                authorization: .oauth(user: "admin@example.com", token: "gAAAAUTHtoKENb3arerJWe"),
+                authorization:
+                    .oauth(
+                        user: "admin@example.com",
+                        token: .bearer("gAAAAUTHtoKENb3arerJWe", Date()),
+                        refresh: .refresh("fakerefreshtokens")
+                    ),
                 persistence: .forSession,
                 space: space
             )

--- a/Core/Tests/AccountTests/URLCredentialStorageTests.swift
+++ b/Core/Tests/AccountTests/URLCredentialStorageTests.swift
@@ -23,10 +23,20 @@ struct URLCredentialStorageTests {
         URLCredentialStorage.shared.deleteAuthorizations(space: space)
         #expect(URLCredentialStorage.shared.credentials(for: space) == nil)
         URLCredentialStorage.shared.set(authorization: .basic(user: "user.name@gmail.com", password: "12345678"), space: space)
-        URLCredentialStorage.shared.set(authorization: .oauth(user: "user.name@gmail.com", token: "zemhu8-omdRiz-zisbov"), space: space)  // Duplicate user
+        URLCredentialStorage.shared
+            .set(
+                authorization:
+                    .oauth(
+                        user: "user.name@gmail.com",
+                        token: Token(value: "zemhu8-omdRiz-zisbov"),
+                        refresh: Token(value: "zemhu8-omdRiz-zisbov")
+                    ),
+                space: space
+            )  // Duplicate user
         #expect(URLCredentialStorage.shared.credentials(for: space)?.count == 1)  // One credential stored per user
         #expect(URLCredentialStorage.shared.authorization(for: "user.name@gmail.com", space: space)?.password == "zemhu8-omdRiz-zisbov")
-        URLCredentialStorage.shared.set(authorization: .oauth(user: "user.name@gmail.com", token: ""), space: space)
+        URLCredentialStorage.shared
+            .set(authorization: .oauth(user: "user.name@gmail.com", token: Token(value: "zemhu8-omdRiz-zisbov"), refresh: Token(value: "zemhu8-omdRiz-zisbov")), space: space)
         #expect(URLCredentialStorage.shared.credentials(for: space) == nil)
     }
 

--- a/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
+++ b/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
@@ -30,4 +30,28 @@ struct URLRequestTests {
         )
         #expect(try URLRequest.token(request, code: "0123456789").url == URL(string: "https://example.com/token"))
     }
+
+    @Test func refreshToken() async throws {
+        let request: OAuth2.Request = try OAuth2.Request(
+            authURI: "https://example.com/authorize",
+            tokenURI: "https://example.com/token",
+            redirectURI: "com.example:/oauth2redirect",
+            responseType: "code",
+            scope: [
+                "mail-w"
+            ],
+            clientID: "Cl13n+-ID",
+            hosts: [
+                "example.com",
+                "examplemail.com"
+            ]
+        )
+        #expect(try URLRequest.refreshToken(request, refreshToken: "0123456789").httpMethod == "POST")
+        #expect(
+            try URLRequest.refreshToken(request, refreshToken: "0123456789").httpBody
+                == "client_id=Cl13n+-ID&client_secret=&redirect_uri=com.example:/oauth2redirect&grant_type=refresh_token&refresh_token=0123456789"
+                .data(using: .utf8)
+        )
+        #expect(try URLRequest.refreshToken(request, refreshToken: "0123456789").url == URL(string: "https://example.com/token"))
+    }
 }

--- a/Thunderbird/Thunderbird/Account/AccountAuth/AccountInformation.swift
+++ b/Thunderbird/Thunderbird/Account/AccountAuth/AccountInformation.swift
@@ -27,12 +27,14 @@ struct AccountInformation: View {
     @State private var password: String = ""
     @State private var error: Error?
     @State private var loginServer: Server = Server(.imap)
+    @State private var loginAuth: Authorization = Server(.imap).authorization
 
     private func refreshAccount() {
         account = emailAddress.isEmailAddress ? Account(emailAddress, provider: config?.emailProvider) : nil
         guard let account = account else { return }
         guard let incomingServer = account.incomingServer else { return }
         loginServer = incomingServer
+        loginAuth = loginServer.authorization
     }
 
     var body: some View {
@@ -63,16 +65,18 @@ struct AccountInformation: View {
                     .buttonStyle(.plain)
                 if account?.incomingServer?.authenticationType != nil {
                     AuthorizationView(
-                        $loginServer.authorization,
+                        $loginAuth,
                         error: $error,
                         for: loginServer.username,
                         authenticationType: loginServer.authenticationType
-                    ).onChange(of: loginServer.authorization) {
+                    ).onChange(of: loginAuth) {
                         guard var account = account else { return }
-                        var incomingServerInfo = account.incomingServer?.clone() ?? Server(.imap)
-                        var outgoingServerInfo = account.outgoingServer?.clone() ?? Server(.smtp)
-                        incomingServerInfo.authorization = loginServer.authorization
-                        outgoingServerInfo.authorization = loginServer.authorization
+                        var incomingServerInfo = account.incomingServer ?? Server(.imap)
+                        var outgoingServerInfo = account.outgoingServer ?? Server(.smtp)
+                        incomingServerInfo.authorization = loginAuth
+                        outgoingServerInfo.authorization = loginAuth
+                        incomingServerInfo.username = emailAddress
+                        outgoingServerInfo.username = emailAddress
                         account.servers = [incomingServerInfo, outgoingServerInfo]
                         accounts.set(account)
                     }

--- a/Thunderbird/Thunderbird/Account/AccountAuth/ManualServerSetup.swift
+++ b/Thunderbird/Thunderbird/Account/AccountAuth/ManualServerSetup.swift
@@ -70,7 +70,6 @@ struct ManualServerSetup: View {
 
             } else {
                 Section(header: Text("account_incoming_server_label")) {
-
                     TextEntryWrapper("account_server_settings_server_label", "server.example.com", $incomingHostname)
                     NumEntryWrapper("account_server_settings_port_label", "443", $incomingPort)
                     Picker("account_server_settings_authentication_label", selection: $incomingServer.authenticationType) {
@@ -135,7 +134,6 @@ struct ManualServerSetup: View {
             Button(
                 action: {
                     // TODO: Need validation
-
                     incomingServer.connectionSecurity = inSelectedSecurity ? ConnectionSecurity.tls : ConnectionSecurity.none
                     incomingServer.hostname = incomingHostname
                     incomingServer.port = incomingPort ?? 443
@@ -190,7 +188,10 @@ public extension Server {
         )
         switch authorization {
         case .basic(let user, let password): print("basic(user: \(user); password: \(password))")
-        case .oauth(let user, let password): print("oauth(user: \(user); password: \(password))")
+        case .oauth(let user, let password, let refresh):
+            print(
+                "oauth(user: \(user); password: \(password) ; \(refresh)"
+            )
         case .none: print("none")
         }
         server.authorization = authorization

--- a/Thunderbird/Thunderbird/Account/AuthorizationView.swift
+++ b/Thunderbird/Thunderbird/Account/AuthorizationView.swift
@@ -18,8 +18,9 @@ struct AuthorizationView: View {
         switch authorization.wrappedValue {
         case .basic(_, let password):
             self.password = password
-        case .oauth(_, let token):
+        case .oauth(_, let token, let refreshToken):
             self.token = token
+            self.refreshToken = refreshToken
         case .none:
             break
         }
@@ -30,6 +31,7 @@ struct AuthorizationView: View {
     @Binding private var error: Error?
     @State private var password: String = ""
     @State private var token: Token?
+    @State private var refreshToken: Token?
 
     // MARK: View
     var body: some View {
@@ -40,10 +42,10 @@ struct AuthorizationView: View {
                     authorization = .basic(user: username, password: password)
                 }
         case .oAuth2:
-            OAuthButton(username, token: $token, error: $error)
+            OAuthButton(username, token: $token, refreshToken: $refreshToken, error: $error)
                 .onChange(of: token, initial: true) {
-                    if let token {
-                        authorization = .oauth(user: username, token: token)
+                    if let token, let refreshToken {
+                        authorization = .oauth(user: username, token: token, refresh: refreshToken)
                     } else {
                         authorization = .none
                     }

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -60,8 +60,8 @@ struct OAuthButton: View {
             for _ in 0..<retries {
                 let (data, _) = try await URLSession.shared.data(for: tokenRequest)
                 let response = try JSONDecoder().decode(TokenResponse.self, from: data)
-                token = .bearer(response.access_token, Date(timeIntervalSinceNow: TimeInterval(response.expires_in)))
-                refreshToken = .refresh(response.refresh_token)
+                token = .bearer(response.accessToken, Date(timeIntervalSinceNow: TimeInterval(response.expiresIn)))
+                refreshToken = .refresh(response.refreshToken)
             }
 
         } catch {

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -88,12 +88,6 @@ struct OAuthButton: View {
     }
 }
 
-struct TokenResponse: Codable {
-    let access_token: String
-    let expires_in: Int
-    let refresh_token: String
-}
-
 #Preview("OAuth Button") {
     @Previewable @State var token: Token?
     @Previewable @State var refreshToken: Token?

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -10,31 +10,36 @@ import SwiftUI
 struct OAuthButton: View {
     let emailAddress: String
 
-    init(_ emailAddress: String = "", token: Binding<Token?>, error: Binding<Error?>) {
+    init(_ emailAddress: String = "", token: Binding<Token?>, refreshToken: Binding<Token?>, error: Binding<Error?>) {
         self.emailAddress = emailAddress
         _token = token
         _error = error
+        _refreshToken = refreshToken
     }
 
     @Binding private var token: Token?
     @Binding private var error: Error?
+    @Binding private var refreshToken: Token?
     @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @State private var request: OAuth2.Request?
 
     private func authenticate() async {
-        do {
-            error = nil
-            guard let request else { return }
-            let _: URL = try await webAuthenticationSession.authenticate(
-                using: request.authURL(hint: emailAddress),
-                callback: .customScheme("\(Bundle.main.schemes.first!)"),
-                additionalHeaderFields: [:])
-
-            // TODO: Exchange auth code for bearer or access/refresh token; for now, succeed here and return fake bearer token...
-            token = .bearer("fake-1e911257e86b1f194daa-0-a89faae5c11f")
-        } catch {
-            self.error = error
+        let retries = 2
+        for _ in 0..<retries {
+            do {
+                error = nil
+                guard let request else { return }
+                let authURL: URL = try await webAuthenticationSession.authenticate(
+                    using: request.authURL(hint: emailAddress),
+                    callback: .customScheme("\(Bundle.main.schemes.first!)"), additionalHeaderFields: [:])
+                let queryItems = URLComponents(string: authURL.absoluteString)?.queryItems
+                let code = (queryItems?.filter({ $0.name == "code" }).first?.value)!
+                await getToken(code: code)
+            } catch {
+                self.error = error
+            }
         }
+
     }
 
     private func configure() async {
@@ -44,6 +49,25 @@ struct OAuthButton: View {
         } catch {
             self.error = error
         }
+    }
+
+    private func getToken(code: String) async {
+        let retries = 3
+        error = nil
+        guard let request else { return }
+        do {
+            let tokenRequest = try URLRequest.token(request, code: code)
+            for _ in 0..<retries {
+                let (data, _) = try await URLSession.shared.data(for: tokenRequest)
+                let response = try JSONDecoder().decode(TokenResponse.self, from: data)
+                token = .bearer(response.access_token, Date(timeIntervalSinceNow: TimeInterval(response.expires_in)))
+                refreshToken = .refresh(response.refresh_token)
+            }
+
+        } catch {
+            self.error = error
+        }
+
     }
 
     // MARK: View
@@ -64,9 +88,16 @@ struct OAuthButton: View {
     }
 }
 
+struct TokenResponse: Codable {
+    let access_token: String
+    let expires_in: Int
+    let refresh_token: String
+}
+
 #Preview("OAuth Button") {
     @Previewable @State var token: Token?
+    @Previewable @State var refreshToken: Token?
     @Previewable @State var error: Error?
 
-    OAuthButton("example@thunderbird.net", token: $token, error: $error)
+    OAuthButton("example@thunderbird.net", token: $token, refreshToken: $refreshToken, error: $error)
 }


### PR DESCRIPTION
## Contribution Summary
When google OAuth2 login flow is complete, uses code to request token. Successful request creates OAuth authentication object with token, expiration date, and refresh token. Retries up to 3 time if unsuccessful.
Closes #399 #398 

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
