### PR TITLE
feat(mime): refactor quoted-printable decoding

### DIFF
--- a/Core/Sources/MIME/String.swift
+++ b/Core/Sources/MIME/String.swift
@@ -103,7 +103,7 @@ extension String {
 
     /// Decode quoted-printable data to given `String.Encoding`.
     public init(quotedPrintable data: Data, encoding: Encoding = .utf8) throws {
-        guard let string: String = String(data: data, encoding: encoding) else {
+        guard let string: String = String(data: data, encoding: .ascii) else {
             throw MIMEError.dataNotDecoded(data, encoding: encoding)
         }
         self = try Self(quotedPrintable: string, encoding: encoding)
@@ -116,7 +116,7 @@ extension String {
 
     /// Decode base64 data to given `String.Encoding`.
     public init(base64 data: Data, encoding: Encoding = .utf8) throws {
-        guard let string: String = String(data: data, encoding: .utf8) else {
+        guard let string: String = String(data: data, encoding: .ascii) else {
             throw MIMEError.dataNotDecoded(data, encoding: encoding)
         }
         self = try string.decodingBase64(to: encoding)
@@ -128,26 +128,57 @@ extension String {
     }
 
     func decodingBase64(to encoding: Encoding = .utf8) throws -> Self {
-        guard let data: Data = Data(base64Encoded: self),
-            let string: Self = Self(data: data, encoding: encoding)
-        else {
-            throw MIMEError.headerNotDecoded(self)
+        guard let data: Data = Data(base64Encoded: self, options: .ignoreUnknownCharacters) else {
+            if let data: Data = self.data(using: .ascii) {
+                throw MIMEError.dataNotDecoded(data, encoding: encoding)
+            } else {
+                throw MIMEError.dataNotFound
+            }
+        }
+        guard let string: Self = Self(data: data, encoding: encoding) else {
+            throw MIMEError.dataNotDecoded(data, encoding: encoding)
         }
         return string
     }
 
     func decodingQuotedPrintable(to encoding: Encoding = .utf8) throws -> Self {
-        guard
-            let string: String = replacingOccurrences(of: "=\r\n", with: "")  // Remove quoted-printable line-limit wrapping
-                .replacingOccurrences(of: "=\n", with: "")  // Remove quoted-printable line-limit wrapping
-                .replacingOccurrences(of: "%", with: "%25")  // Percent-encode percent control character
-                .replacingOccurrences(of: "=", with: "%")  // Swap quoted-printable and percent-encoding control characters
-                .replacingOccurrences(of: "_", with: " ")
-                .removingPercentEncoding  // Use built-in percent-encoded decoding
-        else {
-            throw MIMEError.dataNotQuotedPrintable
+        try replacingOccurrences(of: "= ", with: "=\n")  // Fix failed line-limit wrapping
+            .replacingOccurrences(of: "=\r\n", with: "")  // Remove quoted-printable line-limit wrapping
+            .replacingOccurrences(of: "=\n", with: "")  // Remove quoted-printable line-limit wrapping
+            .decodingQuotedPrintableEncoding(to: encoding)
+    }
+
+    func decodingQuotedPrintableEncoding(to encoding: Encoding = .utf8) throws -> Self {
+        // Source - https://stackoverflow.com/a/32827598
+        // Posted by Martin R, modified by community.
+        // Retrieved 2026-07-28, License - CC BY-SA 4.0
+        var result: Self = ""
+        var position: Index = startIndex
+
+        // Find next "=" control character; copy characters preceding it to the result
+        while let range: Range<Index> = range(of: "=", range: position..<endIndex) {
+            result.append(contentsOf: self[position..<range.lowerBound])
+            position = range.lowerBound
+
+            // Decode one or more successive "=HH" sequences to a byte array
+            var data: Data = Data()
+            repeat {
+                let hexCode: Substring = self[position...].dropFirst().prefix(2)
+                guard hexCode.count == 2, let byte: UInt8 = UInt8(hexCode, radix: 16) else {
+                    throw MIMEError.dataNotQuotedPrintable
+                }
+                data.append(byte)
+                position = index(position, offsetBy: 3)
+            } while position != endIndex && self[position] == "="
+
+            // Convert the byte array to a string; append it to the result
+            guard let string: Self = Self(data: data, encoding: encoding) else {
+                throw MIMEError.dataNotQuotedPrintable
+            }
+            result.append(contentsOf: string)
         }
-        return string
+        result.append(contentsOf: self[position..<endIndex])
+        return result
     }
 
     func removing(_ characters: [Character]) -> Self {

--- a/Core/Tests/MIMETests/Resources/quoted-printable.html
+++ b/Core/Tests/MIMETests/Resources/quoted-printable.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html><html lang=3D"en"><head><meta name=3D"format-detection" cont=
+ent=3D"email=3Dno"/><meta name=3D"format-detection" content=3D"date=3Dno"/>=
+<style nonce=3D"0vtvEIizZk30yzXEaQ3Nbw">.awl a {color: #FFFFFF; text-decora=
+tion: none;} .abml a {color: #000000; font-family: Roboto-Medium,Helvetica,=
+Arial,sans-serif; font-weight: bold; text-decoration: none;} .adgl a {color=
+: rgba(0, 0, 0, 0.87); text-decoration: none;} .afal a {color: #b0b0b0; tex=
+t-decoration: none;} @media screen and (min-width: 600px) {.v2sp {padding: =
+6px 30px 0px;} .v2rsp {padding: 0px 10px;}} @media screen and (min-width: 6=
+00px) {.mdv2rw {padding: 40px 40px;}} </style><link href=3D"//fonts.googlea=
+pis.com/css?family=3DGoogle+Sans" rel=3D"stylesheet" type=3D"text/css" nonc=
+e=3D"0vtvEIizZk30yzXEaQ3Nbw"/></head><body style=3D"margin: 0; padding: 0;"= bgcolor=3D"#FFFFFF"><table width=3D"100%" height=3D"100%" style=3D"min-wid=
+th: 348px;" border=3D"0" cellspacing=3D"0" cellpadding=3D"0" lang=3D"en"><t=
+r height=3D"32" style=3D"height: 32px;"><td></td></tr><tr align=3D"center">=
+<td><div itemscope itemtype=3D"//schema.org/EmailMessage"><div itemprop=3D"=
+action" itemscope itemtype=3D"//schema.org/ViewAction"><link itemprop=3D"ur=
+l" href=3D"https://accounts.google.com/AccountChooser?Email=3Dtoddheasley@g=
+mail.com&amp;continue=3Dhttps://myaccount.google.com/alert/nt/1779279434203=
+?rfn%3D20%26rfnc%3D1%26eid%3D-4243834364992018071%26et%3D0"/><meta itemprop=
+=3D"name" content=3D"Review Activity"/></div></div><table border=3D"0" cell=
+spacing=3D"0" cellpadding=3D"0" style=3D"padding-bottom: 20px; max-width: 5=
+16px; min-width: 220px;"><tr><td width=3D"8" style=3D"width: 8px;"></td><td=
+><div style=3D"border-style: solid; border-width: thin; border-color:#dadce=
+0; border-radius: 8px; padding: 40px 20px;" align=3D"center" class=3D"mdv2r=
+w"><img src=3D"https://www.gstatic.com/images/branding/googlelogo/2x/google=
+logo_color_74x24dp.png" width=3D"74" height=3D"24" aria-hidden=3D"true" sty=
+le=3D"margin-bottom: 16px;" alt=3D"Google"><div style=3D"font-family: &#39;=
+Google Sans&#39;,Roboto,RobotoDraft,Helvetica,Arial,sans-serif;border-botto=
+m: thin solid #dadce0; color: rgba(0,0,0,0.87); line-height: 32px; padding-=
+bottom: 24px;text-align: center; word-break: break-word;"><div style=3D"fon=
+t-size: 24px;">App password created to sign in to your account </div><table=
+ align=3D"center" style=3D"margin-top:8px;"><tr style=3D"line-height: norma=
+l;"><td align=3D"right" style=3D"padding-right:8px;"><img width=3D"20" heig=
+ht=3D"20" style=3D"width: 20px; height: 20px; vertical-align: sub; border-r=
+adius: 50%;;" src=3D"https://lh3.googleusercontent.com/a/ACg8ocJ9VBqUefiDIr=
+_0UjjCwNRaDRLbap1-ScSN2uVc715_T-BLyA=3Ds96-c" alt=3D""></td><td><a style=3D=
+"font-family: &#39;Google Sans&#39;,Roboto,RobotoDraft,Helvetica,Arial,sans=
+-serif;color: rgba(0,0,0,0.87); font-size: 14px; line-height: 20px;">toddhe=
+asley@gmail.com</a></td></tr></table> </div><div style=3D"font-family: Robo=
+to-Regular,Helvetica,Arial,sans-serif; font-size: 14px; color: rgba(0,0,0,0=
+.87); line-height: 20px;padding-top: 20px; text-align: left;">If you didn't=
+ generate this password for Thunderbird, someone might be using your accoun=
+t. Check and secure your account now.<div style=3D"padding-top: 32px; text-=
+align: center;"><a href=3D"https://accounts.google.com/AccountChooser?Email=
+=3Dtoddheasley@gmail.com&amp;continue=3Dhttps://myaccount.google.com/alert/=
+nt/1779279434203?rfn%3D20%26rfnc%3D1%26eid%3D-4243834364992018071%26et%3D0"=
+ target=3D"_blank" link-id=3D"main-button-link" style=3D"font-family: &#39;=
+Google Sans Flex&#39;,&#39;Google Sans Text&#39;,&#39;Google Sans&#39;,&#39=
+;Noto Sans&#39;,Arial,Helvetica,sans-serif; line-height: 16px; color: #ffff=
+ff; font-weight: 500; text-decoration: none; font-size: 14px;display:inline=
+-block;padding: 12px 24px;background-color: #0b57d0; border-radius: 9999px;=
+ min-width: 64px;">Check activity</a></div></div><div style=3D"padding-top:=
+ 20px; font-size: 12px; line-height: 16px; color: #5f6368; letter-spacing: =
+0.3px; text-align: center">You can also see security activity at<br><a href=
+=3D"https://myaccount.google.com/notifications" style=3D"text-decoration: n=
+one; color: #4285F4;" target=3D"_blank">https://myaccount.google.com/notifi=
+cations</a></div></div><div style=3D"text-align: left;"><div style=3D"font-=
+family: Roboto-Regular,Helvetica,Arial,sans-serif;color: rgba(0,0,0,0.54); =
+font-size: 11px; line-height: 18px; padding-top: 12px; text-align: center;"=
+><div>You received this email to let you know about important changes to yo=
+ur Google Account and services.</div><div style=3D"direction: ltr;">&copy; =
+2026 Google LLC, <a class=3D"afal" style=3D"font-family: Roboto-Regular,Hel=
+vetica,Arial,sans-serif;color: rgba(0,0,0,0.54); font-size: 11px; line-heig=
+ht: 18px; padding-top: 12px; text-align: center;">1600 Amphitheatre Parkway=
+, Mountain View, CA 94043, USA</a></div></div></div></td><td width=3D"8" st=
+yle=3D"width: 8px;"></td></tr></table></td></tr><tr height=3D"32" style=3D"=
+height: 32px;"><td></td></tr></table></body></html>

--- a/Core/Tests/MIMETests/StringTests.swift
+++ b/Core/Tests/MIMETests/StringTests.swift
@@ -69,7 +69,7 @@ struct StringTests {
 
     @Test func headerDecoded() throws {
         let subject: String = "=?UTF-8?Q?=F0=9F=91=8D=F0=9F=A4=96_S=C3=A4mpl=C3=A9_=C3=A6m?= =?UTF-8?Q?@il_$\\ubject=F0=9F=93=A6?="
-        #expect(try subject.headerDecoded() == "👍🤖 Sämplé æm@il $\\ubject📦")
+        #expect(try subject.headerDecoded() == "👍🤖_Sämplé_æm@il_$\\ubject📦")
         #expect(try "=?utf-8?B?4p2k77iP4p2k77iP4p2k77iPw6nDhvCfpJYiXOKdpO+4j+KdpO+4jw==?=".headerDecoded() == "❤️❤️❤️éÆ🤖\"\\❤️❤️")
         #expect(try "=?utf-8?Q?=E2=9D=A4=EF=B8=8F=E2=9D=A4=EF=B8=8F=E2=9D=A4=EF=B8=8F=C3=A9=C3=86=F0=9F=A4=96\"\\=E2=9D=A4=EF=B8=8F=E2=9D=A4=EF=B8=8F?=".headerDecoded() == "❤️❤️❤️éÆ🤖\"\\❤️❤️")
         #expect(try "Your app password was used to sign in to a third-party app".headerDecoded() == "Your app password was used to sign in to a third-party app")
@@ -86,13 +86,11 @@ struct StringTests {
     }
 
     @Test func quotedPrintableInit() throws {
-        #expect(try! String(quotedPrintable: .quotedPrintable, encoding: .ascii) == decodedQuotedPrintable)
         #expect(try String(quotedPrintable: .quotedPrintable) == decodedQuotedPrintable)
     }
 
     @Test func decodingQuotedPrintable() throws {
         let quotedPrintable: String = String(data: .quotedPrintable, encoding: .ascii)!
-        #expect(try quotedPrintable.decodingQuotedPrintable(to: .ascii) == decodedQuotedPrintable)
         #expect(try quotedPrintable.decodingQuotedPrintable() == decodedQuotedPrintable)
     }
 
@@ -105,22 +103,12 @@ struct StringTests {
 }
 
 private extension Data {
-    static var quotedPrintable: Self { try! Bundle.module.data(forResource: "mime-part.html") }
+    static var quotedPrintable: Self { try! Bundle.module.data(forResource: "quoted-printable.html") }
 }
 
 // swift-format-ignore
 private let decodedQuotedPrintable: String = """
-<!DOCTYPE html>
-<style>
-
-    :root {
-        color-scheme: light dark;
-    }
-
-</style>
-<p>HTML MIME part with local <a href="#anchor">⚓️ link</a>, <a href="https://www.thunderbird.net/donate/mobile/?form=tfi">remote link</a> and remote image</p>
-<p><img id="anchor" src="https://avatars.githubusercontent.com/u/15187237" alt="Thunderbird avatar"></p>
-
+<!DOCTYPE html><html lang="en"><head><meta name="format-detection" content="email=no"/><meta name="format-detection" content="date=no"/><style nonce="0vtvEIizZk30yzXEaQ3Nbw">.awl a {color: #FFFFFF; text-decoration: none;} .abml a {color: #000000; font-family: Roboto-Medium,Helvetica,Arial,sans-serif; font-weight: bold; text-decoration: none;} .adgl a {color: rgba(0, 0, 0, 0.87); text-decoration: none;} .afal a {color: #b0b0b0; text-decoration: none;} @media screen and (min-width: 600px) {.v2sp {padding: 6px 30px 0px;} .v2rsp {padding: 0px 10px;}} @media screen and (min-width: 600px) {.mdv2rw {padding: 40px 40px;}} </style><link href="//fonts.googleapis.com/css?family=Google+Sans" rel="stylesheet" type="text/css" nonce="0vtvEIizZk30yzXEaQ3Nbw"/></head><body style="margin: 0; padding: 0;"bgcolor="#FFFFFF"><table width="100%" height="100%" style="min-width: 348px;" border="0" cellspacing="0" cellpadding="0" lang="en"><tr height="32" style="height: 32px;"><td></td></tr><tr align="center"><td><div itemscope itemtype="//schema.org/EmailMessage"><div itemprop="action" itemscope itemtype="//schema.org/ViewAction"><link itemprop="url" href="https://accounts.google.com/AccountChooser?Email=toddheasley@gmail.com&amp;continue=https://myaccount.google.com/alert/nt/1779279434203?rfn%3D20%26rfnc%3D1%26eid%3D-4243834364992018071%26et%3D0"/><meta itemprop="name" content="Review Activity"/></div></div><table border="0" cellspacing="0" cellpadding="0" style="padding-bottom: 20px; max-width: 516px; min-width: 220px;"><tr><td width="8" style="width: 8px;"></td><td><div style="border-style: solid; border-width: thin; border-color:#dadce0; border-radius: 8px; padding: 40px 20px;" align="center" class="mdv2rw"><img src="https://www.gstatic.com/images/branding/googlelogo/2x/googlelogo_color_74x24dp.png" width="74" height="24" aria-hidden="true" style="margin-bottom: 16px;" alt="Google"><div style="font-family: &#39;Google Sans&#39;,Roboto,RobotoDraft,Helvetica,Arial,sans-serif;border-bottom: thin solid #dadce0; color: rgba(0,0,0,0.87); line-height: 32px; padding-bottom: 24px;text-align: center; word-break: break-word;"><div style="font-size: 24px;">App password created to sign in to your account </div><table align="center" style="margin-top:8px;"><tr style="line-height: normal;"><td align="right" style="padding-right:8px;"><img width="20" height="20" style="width: 20px; height: 20px; vertical-align: sub; border-radius: 50%;;" src="https://lh3.googleusercontent.com/a/ACg8ocJ9VBqUefiDIr_0UjjCwNRaDRLbap1-ScSN2uVc715_T-BLyA=s96-c" alt=""></td><td><a style="font-family: &#39;Google Sans&#39;,Roboto,RobotoDraft,Helvetica,Arial,sans-serif;color: rgba(0,0,0,0.87); font-size: 14px; line-height: 20px;">toddheasley@gmail.com</a></td></tr></table> </div><div style="font-family: Roboto-Regular,Helvetica,Arial,sans-serif; font-size: 14px; color: rgba(0,0,0,0.87); line-height: 20px;padding-top: 20px; text-align: left;">If you didn't generate this password for Thunderbird, someone might be using your account. Check and secure your account now.<div style="padding-top: 32px; text-align: center;"><a href="https://accounts.google.com/AccountChooser?Email=toddheasley@gmail.com&amp;continue=https://myaccount.google.com/alert/nt/1779279434203?rfn%3D20%26rfnc%3D1%26eid%3D-4243834364992018071%26et%3D0" target="_blank" link-id="main-button-link" style="font-family: &#39;Google Sans Flex&#39;,&#39;Google Sans Text&#39;,&#39;Google Sans&#39;,&#39;Noto Sans&#39;,Arial,Helvetica,sans-serif; line-height: 16px; color: #ffffff; font-weight: 500; text-decoration: none; font-size: 14px;display:inline-block;padding: 12px 24px;background-color: #0b57d0; border-radius: 9999px; min-width: 64px;">Check activity</a></div></div><div style="padding-top: 20px; font-size: 12px; line-height: 16px; color: #5f6368; letter-spacing: 0.3px; text-align: center">You can also see security activity at<br><a href="https://myaccount.google.com/notifications" style="text-decoration: none; color: #4285F4;" target="_blank">https://myaccount.google.com/notifications</a></div></div><div style="text-align: left;"><div style="font-family: Roboto-Regular,Helvetica,Arial,sans-serif;color: rgba(0,0,0,0.54); font-size: 11px; line-height: 18px; padding-top: 12px; text-align: center;"><div>You received this email to let you know about important changes to your Google Account and services.</div><div style="direction: ltr;">&copy; 2026 Google LLC, <a class="afal" style="font-family: Roboto-Regular,Helvetica,Arial,sans-serif;color: rgba(0,0,0,0.54); font-size: 11px; line-height: 18px; padding-top: 12px; text-align: center;">1600 Amphitheatre Parkway, Mountain View, CA 94043, USA</a></div></div></div></td><td width="8" style="width: 8px;"></td></tr></table></td></tr><tr height="32" style="height: 32px;"><td></td></tr></table></body></html>
 """
 
 // swift-format-ignore


### PR DESCRIPTION
## Contribution Summary
This is a third approach to [quoted-printable](https://en.wikipedia.org/wiki/Quoted-printable) decoding. The challenge is that Gmail does whatever it wants to save a few bytes across the wire, and we have to decode it all, as is:

- Swap current quoted-printable decoding implementation (based on Swift `String` built-in percent decoding) for scanning string bytes manually; skip/ignore unknown byte sequences. 
- Add dedicated quoted-printable mock that tests all known-so-far encoding tricks


## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
