### PR TITLE
feat(imap): disable NIO byte-level debug logging

### DIFF
--- a/Core/Sources/IMAP/IMAPClient.swift
+++ b/Core/Sources/IMAP/IMAPClient.swift
@@ -351,7 +351,7 @@ private extension ClientBootstrap {
         Self(group: group).channelInitializer { channel in
             try! channel.pipeline.syncOperations.addHandlers(
                 [
-                    LoggingHandler(logger),
+                    // LoggingHandler(logger), // Enable byte-level logging
                     TLSClientHandler(serverHostname: server.hostname),
                     IMAPClientHandler(parserOptions: .max)
                 ]


### PR DESCRIPTION
## Contribution Summary

Disable the byte-level NIO debug logging in IMAP client. Higher level interface and logging is fully in place now, and the raw TCP buffer dumps are just noise.

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
