### PR TITLE
feat(mime): add Content-ID and Message-ID

### DIFF
--- a/Core/Sources/Account/Mailbox.swift
+++ b/Core/Sources/Account/Mailbox.swift
@@ -80,7 +80,7 @@ extension IMAP.Mailbox.Path {
     var suggestedRights: Mailbox.Rights {
         // IMAP mailbox rights all default to true if MYRIGHTS is
         // unavailable from provider:
-        // https://datatracker.ietf.org/doc/html/rfc8440
+        // https://www.rfc-editor.org/info/rfc8440/
         if let pathSeparator, name.description.components(separatedBy: "\(pathSeparator)")[0].hasPrefix("[Gmail]") {
             // Gmail allows renaming and deleting label mailboxes, but
             // [Gmail]-prefixed internal folders can't be modified.

--- a/Core/Sources/IMAP/Envelope.swift
+++ b/Core/Sources/IMAP/Envelope.swift
@@ -58,7 +58,7 @@ public struct Envelope: Sendable {
 }
 
 extension String {
-    init?(_ messageID: MessageID?) {
+    init?(_ messageID: NIOIMAPCore.MessageID?) {
         guard let messageID else {
             return nil
         }

--- a/Core/Sources/MIME/ContentID.swift
+++ b/Core/Sources/MIME/ContentID.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public typealias MessageID = ContentID
+
+/// Optionally structured Content-ID, used primarily for associating related MIME parts
+/// Suitable for use as IMAP Message-ID, also. Generates new IDs [as recommended](https://www.jwz.org/doc/mid.html): `<1762463150.A51D5B17@example.com>`
+/// Described in [RFC 2822](https://www.rfc-editor.org/info/rfc2822/#section-3.6.4)
+public struct ContentID: CustomStringConvertible, ExpressibleByStringLiteral, Hashable, Identifiable, Sendable {
+
+    /// Make a new ID in the [recommended format.](https://www.jwz.org/doc/mid.html)
+    public init(_ host: String = "", date: Date = Date(), uuid: UUID = UUID()) {
+        let local: String = "\(Int(date.timeIntervalSince1970)).\(uuid.uuidString(1))"
+        if !host.isEmpty {
+            self.init("<\(local)@\(host)>")
+        } else {
+            self.init("<\(local)>")
+        }
+    }
+
+    public init(_ description: String) {
+        // Empty description generates local-only ID from current date and generated UUID
+        self.description = description.isEmpty ? Self().description : description
+    }
+
+    // MARK: CustomStringConvertible
+    public let description: String
+
+    // MARK: ExpressibleByStringLiteral
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(value)
+    }
+
+    // MARK: Identifiable
+    public var id: String { description }
+}

--- a/Core/Sources/MIME/String.swift
+++ b/Core/Sources/MIME/String.swift
@@ -189,6 +189,17 @@ extension String {
         return string
     }
 
+    func unwrapping(_ prefix: String, _ suffix: String) -> Self {
+        var string: Self = "\(self)"
+        if hasPrefix(prefix) {
+            string = "\(string.dropFirst(prefix.count))"
+        }
+        if hasSuffix(suffix) {
+            string = "\(string.dropLast(suffix.count))"
+        }
+        return string
+    }
+
     func trimmed() -> Self {
         trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Core/Sources/MIME/URL.swift
+++ b/Core/Sources/MIME/URL.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension URL {
+
+    /// Use ``MessageID`` with optional part ``ContentID`` as URI with `mid:` scheme
+    /// Described in [RFC 2392](https://www.rfc-editor.org/info/rfc2392)
+    public init(messageID: MessageID, contentID: ContentID? = nil) throws {
+        guard let messageID: String = messageID.description.ascii,
+            var url: Self = Self(string: "mid:\(messageID.unwrapping("<", ">"))")
+        else {
+            throw MIMEError.headerValueNotASCII
+        }
+        if let contentID: String = contentID?.description.ascii {
+            url = url.appending(path: contentID.unwrapping("<", ">"))
+        }
+        self = url
+    }
+
+    /// Use ``ContentID`` as URI with `cid:` scheme
+    /// Described in [RFC 2392](https://www.rfc-editor.org/info/rfc2392)
+    public init(contentID: ContentID) throws {
+        guard let contentID: String = contentID.description.ascii,
+            let url: Self = Self(string: "cid:\(contentID.unwrapping("<", ">"))")
+        else {
+            throw MIMEError.headerValueNotASCII
+        }
+        self = url
+    }
+}

--- a/Core/Sources/SMTP/Email.swift
+++ b/Core/Sources/SMTP/Email.swift
@@ -18,13 +18,8 @@ public struct Email: Identifiable, Sendable {
 
     public var contentType: MIME.ContentType { body.contentType }
 
-    public var messageID: String {
-        // Format: https://www.jwz.org/doc/mid.html
-        let local: String = "\(Int(date.timeIntervalSince1970)).\(id.uuidString(1))"
-        guard let host: String = sender.host else {
-            return "<\(local)>"
-        }
-        return "<\(local)@\(host)>"
+    public var messageID: MessageID {
+        MessageID(sender.host ?? "", date: date, uuid: id)
     }
 
     public init(

--- a/Core/Tests/MIMETests/ContentIDTests.swift
+++ b/Core/Tests/MIMETests/ContentIDTests.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import MIME
+import Testing
+
+struct ContentIDTests {
+    @Test func hostInit() {
+        let date: Date = Date(timeIntervalSince1970: 1762463150.0)
+        let uuid: UUID = UUID(uuidString: "87CC5B3E-28FF-4A3E-9340-8E2DA59DF7E8")!
+        #expect(ContentID("example.com", date: date, uuid: uuid).description == "<1762463150.87CC5B3E@example.com>")
+        #expect(ContentID(date: date, uuid: uuid).description == "<1762463150.87CC5B3E>")
+    }
+
+    @Test func descriptionInit() {
+        #expect(ContentID("<1762463150.A51D5B17@example.com>").description == "<1762463150.A51D5B17@example.com>")
+        #expect(ContentID("FR33$Ty13").description == "FR33$Ty13")
+        #expect(ContentID("").description.components(separatedBy: ".").count == 2)
+        #expect(ContentID("").description.count > 20)
+    }
+}

--- a/Core/Tests/MIMETests/StringTests.swift
+++ b/Core/Tests/MIMETests/StringTests.swift
@@ -100,6 +100,16 @@ struct StringTests {
             try "4p2k77iP4p2k77iPw6nDhvCfpJYi4j+KdpO+4jw==".decodingBase64()
         }
     }
+
+    @Test func unwrapping() {
+        #expect("<1762463150.A51D5B17@example.com>".unwrapping("<", ">") == "1762463150.A51D5B17@example.com")
+        #expect("<1762463150.A51D5B17@example.com>".unwrapping("<", "") == "1762463150.A51D5B17@example.com>")
+        #expect("<1762463150.A51D5B17@example.com>".unwrapping("", ">") == "<1762463150.A51D5B17@example.com")
+        #expect("<1762463150.A51D5B17@example.com>".unwrapping("[", "]") == "<1762463150.A51D5B17@example.com>")
+        #expect("1762463150.A51D5B17@example.com>".unwrapping("<", ">") == "1762463150.A51D5B17@example.com")
+        #expect("<1762463150.A51D5B17@example.com".unwrapping("<", ">") == "1762463150.A51D5B17@example.com")
+        #expect("<1762463150.A51D5B17@example.com>".unwrapping("", "") == "<1762463150.A51D5B17@example.com>")
+    }
 }
 
 private extension Data {

--- a/Core/Tests/MIMETests/URLTests.swift
+++ b/Core/Tests/MIMETests/URLTests.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import MIME
+import Testing
+
+struct URLTests {
+    @Test func messageIDInit() throws {
+        #expect(try URL(messageID: MessageID("<1762463150.A51D5B17@example.com>")).absoluteString == "mid:1762463150.A51D5B17@example.com")
+        #expect(
+            try URL(
+                messageID: MessageID("<1762463150.A51D5B17@example.com>"),
+                contentID: ContentID("part1.example.1762463150.A51D5B17")
+            ).absoluteString == "mid:1762463150.A51D5B17@example.com/part1.example.1762463150.A51D5B17"
+        )
+        #expect(throws: MIMEError.headerValueNotASCII) {
+            try URL(messageID: MessageID("not.æscii"))
+        }
+    }
+
+    @Test func contentIDInit() throws {
+        #expect(try URL(contentID: ContentID("<1762463150.A51D5B17@example.com>")).absoluteString == "cid:1762463150.A51D5B17@example.com")
+        #expect(try URL(contentID: ContentID("part1.example.1762463150.A51D5B17")).absoluteString == "cid:part1.example.1762463150.A51D5B17")
+        #expect(throws: MIMEError.headerValueNotASCII) {
+            try URL(contentID: ContentID("not.æscii"))
+        }
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Core `MIME` library needs `Content-ID`, as described in [section 3 of RFC 2822]([RFC 2822](https://www.rfc-editor.org/info/rfc2822/#section-3.6.4), for the purpose of associating related MIME parts.

- Add `MIME.ContentID` type and `MIME.MessageID` typealias
- Add `URL` constructors for specifying message and/or content paths

Close #447 

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
