### PR TITLE
Implement thunderbird oauth with pkce

### DIFF
--- a/Core/Sources/Autoconfiguration/OAuth2.swift
+++ b/Core/Sources/Autoconfiguration/OAuth2.swift
@@ -3,8 +3,27 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import CryptoKit
 
 public struct OAuth2: Decodable {
+    public struct PKCE: Equatable, Sendable {
+        public let codeVerifier: String
+        public let codeChallenge: String
+
+        public init() {
+            var generator = SystemRandomNumberGenerator()
+            let bytes = (0..<32).map { _ in
+                UInt8.random(in: UInt8.min...UInt8.max, using: &generator)
+            }
+            self.init(codeVerifier: Data(bytes).base64URLEncodedString())
+        }
+
+        init(codeVerifier: String) {
+            self.codeVerifier = codeVerifier
+            self.codeChallenge = Data(SHA256.hash(data: Data(codeVerifier.utf8))).base64URLEncodedString()
+        }
+    }
+
     public struct Request: Equatable, Sendable, Decodable, Encodable, Hashable {
         public let authURI: String
         public let tokenURI: String
@@ -14,13 +33,15 @@ public struct OAuth2: Decodable {
         public let hosts: [String]
         public let clientID: String
 
-        public func authURL(hint: String? = nil) -> URL {
+        public func authURL(hint: String? = nil, pkce: PKCE) -> URL {
             var components: URLComponents = URLComponents(string: authURI)!  // Validated during init
             components.queryItems = [
                 URLQueryItem(name: "client_id", value: clientID),
                 URLQueryItem(name: "redirect_uri", value: redirectURI),
                 URLQueryItem(name: "response_type", value: responseType),
-                URLQueryItem(name: "scope", value: scope.joined(separator: " "))
+                URLQueryItem(name: "scope", value: scope.joined(separator: " ")),
+                URLQueryItem(name: "code_challenge", value: pkce.codeChallenge),
+                URLQueryItem(name: "code_challenge_method", value: "S256")
             ]
             if let hint, !hint.isEmpty {  // Prepopulate email address for specific user
                 components.queryItems?.append(URLQueryItem(name: "login_hint", value: hint))
@@ -28,14 +49,15 @@ public struct OAuth2: Decodable {
             return components.url!
         }
 
-        public func tokenURL(_ code: String) -> URL {
+        public func tokenURL(_ code: String, pkce: PKCE) -> URL {
             var components: URLComponents = URLComponents(string: tokenURI)!  // Validated during init
             components.queryItems = [
                 URLQueryItem(name: "client_id", value: clientID),
                 URLQueryItem(name: "client_secret", value: ""),
                 URLQueryItem(name: "redirect_uri", value: redirectURI),
                 URLQueryItem(name: "grant_type", value: "authorization_code"),
-                URLQueryItem(name: "code", value: code)
+                URLQueryItem(name: "code", value: code),
+                URLQueryItem(name: "code_verifier", value: pkce.codeVerifier)
             ]
             return components.url!
         }
@@ -106,5 +128,14 @@ public struct OAuth2: Decodable {
 
     private enum Key: CodingKey {
         case authURL, issuer, scope, tokenURL
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/Core/Sources/Autoconfiguration/URLRequest.swift
+++ b/Core/Sources/Autoconfiguration/URLRequest.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 extension URLRequest {
-    public static func token(_ request: OAuth2.Request, code: String) throws -> Self {
+    public static func token(_ request: OAuth2.Request, code: String, pkce: OAuth2.PKCE) throws -> Self {
         guard
             var components: URLComponents = URLComponents(
-                url: request.tokenURL(code),
+                url: request.tokenURL(code, pkce: pkce),
                 resolvingAgainstBaseURL: false
             ), let httpBody: Data = components.percentEncodedQuery?.data(using: .utf8)
         else {

--- a/Core/Tests/AutoconfigurationTests/OAuth2Tests.swift
+++ b/Core/Tests/AutoconfigurationTests/OAuth2Tests.swift
@@ -7,6 +7,42 @@ import Foundation
 import Testing
 
 struct OAuth2Tests {
+    @Test func pkceGeneratesRFC7636Verifier() {
+        let pkce = OAuth2.PKCE()
+        let allowedCharacters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+        #expect(pkce.codeVerifier.count == 43)
+        #expect(pkce.codeVerifier.unicodeScalars.allSatisfy { allowedCharacters.contains($0) })
+    }
+
+    @Test func pkceRFC7636TestVector() {
+        let pkce = OAuth2.PKCE(codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+
+        #expect(pkce.codeChallenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test func authURLIncludesPKCEChallenge() throws {
+        let request: OAuth2.Request = try OAuth2.Request(
+            authURI: "https://example.com/authorize",
+            tokenURI: "https://example.com/token",
+            redirectURI: "com.example:/oauth2redirect",
+            responseType: "code",
+            scope: [
+                "mail-w"
+            ],
+            clientID: "Cl13n+-ID"
+        )
+        let pkce = OAuth2.PKCE(codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+        let queryItems = URLComponents(
+            url: request.authURL(hint: "user@example.com", pkce: pkce),
+            resolvingAgainstBaseURL: false
+        )?.queryItems
+
+        #expect(queryItems?.first(where: { $0.name == "code_challenge" })?.value == pkce.codeChallenge)
+        #expect(queryItems?.first(where: { $0.name == "code_challenge_method" })?.value == "S256")
+        #expect(queryItems?.first(where: { $0.name == "login_hint" })?.value == "user@example.com")
+    }
+
     @Test func matches() throws {
         let request: OAuth2.Request = try OAuth2.Request(
             authURI: "https://example.com/authorize",

--- a/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
+++ b/Core/Tests/AutoconfigurationTests/URLRequestTests.swift
@@ -22,13 +22,16 @@ struct URLRequestTests {
                 "examplemail.com"
             ]
         )
-        #expect(try URLRequest.token(request, code: "0123456789").httpMethod == "POST")
+        let pkce = OAuth2.PKCE(codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+        let tokenRequest = try URLRequest.token(request, code: "0123456789", pkce: pkce)
+
+        #expect(tokenRequest.httpMethod == "POST")
         #expect(
-            try URLRequest.token(request, code: "0123456789").httpBody
-                == "client_id=Cl13n+-ID&client_secret=&redirect_uri=com.example:/oauth2redirect&grant_type=authorization_code&code=0123456789"
+            tokenRequest.httpBody
+                == "client_id=Cl13n+-ID&client_secret=&redirect_uri=com.example:/oauth2redirect&grant_type=authorization_code&code=0123456789&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
                 .data(using: .utf8)
         )
-        #expect(try URLRequest.token(request, code: "0123456789").url == URL(string: "https://example.com/token"))
+        #expect(tokenRequest.url == URL(string: "https://example.com/token"))
     }
 
     @Test func refreshToken() async throws {
@@ -46,12 +49,13 @@ struct URLRequestTests {
                 "examplemail.com"
             ]
         )
-        #expect(try URLRequest.refreshToken(request, refreshToken: "0123456789").httpMethod == "POST")
+        let tokenRequest = try URLRequest.refreshToken(request, refreshToken: "0123456789")
+        #expect(tokenRequest.httpMethod == "POST")
         #expect(
-            try URLRequest.refreshToken(request, refreshToken: "0123456789").httpBody
+            tokenRequest.httpBody
                 == "client_id=Cl13n+-ID&client_secret=&redirect_uri=com.example:/oauth2redirect&grant_type=refresh_token&refresh_token=0123456789"
                 .data(using: .utf8)
         )
-        #expect(try URLRequest.refreshToken(request, refreshToken: "0123456789").url == URL(string: "https://example.com/token"))
+        #expect(tokenRequest.url == URL(string: "https://example.com/token"))
     }
 }

--- a/Thunderbird/Thunderbird/Account/OAuth2.swift
+++ b/Thunderbird/Thunderbird/Account/OAuth2.swift
@@ -92,7 +92,7 @@ extension OAuth2.Request: @retroactive CaseIterable {
         try! Self(
             authURI: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth",
             tokenURI: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token",
-            redirectURI: "\(Bundle.main.schemes.first!)://oauth2redirect",
+            redirectURI: "\(Bundle.main.schemes.first!):/oauth2redirect",
             responseType: "code",
             scope: [
                 "openid",
@@ -100,7 +100,7 @@ extension OAuth2.Request: @retroactive CaseIterable {
                 "email",
                 "offline_access"
             ],
-            clientID: "mobile-android-thunderbird",
+            clientID: "mobile-ios-thunderbird",
             hosts: [
                 "tb.pro",
                 "thundermail.com"

--- a/Thunderbird/Thunderbird/Account/OAuthButton.swift
+++ b/Thunderbird/Thunderbird/Account/OAuthButton.swift
@@ -38,12 +38,13 @@ struct OAuthButton: View {
                 error = nil
                 guard let authConfig else { return }
                 if !hasSucceeded {
+                    let pkce = OAuth2.PKCE()
                     let authURL: URL = try await webAuthenticationSession.authenticate(
-                        using: authConfig.authURL(hint: emailAddress),
+                        using: authConfig.authURL(hint: emailAddress, pkce: pkce),
                         callback: .customScheme("\(Bundle.main.schemes.first!)"), additionalHeaderFields: [:])
                     let queryItems = URLComponents(string: authURL.absoluteString)?.queryItems
                     let code = (queryItems?.filter({ $0.name == "code" }).first?.value)!
-                    await getToken(code: code)
+                    await getToken(code: code, pkce: pkce)
                     hasSucceeded = true
                 }
             } catch {
@@ -62,13 +63,13 @@ struct OAuthButton: View {
         }
     }
 
-    private func getToken(code: String) async {
+    private func getToken(code: String, pkce: OAuth2.PKCE) async {
         let retries = 3
         error = nil
         guard let authConfig else { return }
         for _ in 0..<retries {
             do {
-                let tokenRequest = try URLRequest.token(authConfig, code: code)
+                let tokenRequest = try URLRequest.token(authConfig, code: code, pkce: pkce)
                 let (data, _) = try await URLSession.shared.data(for: tokenRequest)
                 let response = try JSONDecoder().decode(TokenResponse.self, from: data)
                 token = .bearer(response.accessToken, Date(timeIntervalSinceNow: TimeInterval(response.expiresIn)))


### PR DESCRIPTION
## Contribution Summary
Adding PKCE to the OAuth section, allowing login via Thundermail
Closes #458 

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
