### PR TITLE
chore(ci): Bump Shippable Builds SDK Version

### DIFF
--- a/.github/workflows/shippable-builds.yml
+++ b/.github/workflows/shippable-builds.yml
@@ -6,7 +6,7 @@ env:
   DEFAULT_VERSION: &default_version "1.0"
   DEFAULT_NOTIFY_TESTERS: &default_notify_testers false
   DEFAULT_TEST_DEVICE: &default_test_device "iPhone 17"
-  XCODE_VERSION: "26.1"
+  XCODE_VERSION: "26.5"
 
 on:
   schedule:
@@ -55,7 +55,25 @@ jobs:
           xcode-select-version: ${{ env.XCODE_VERSION }}
 
       - name: Ensure iOS Simulator Runtime installed
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          # First check simulator runtime is already installed
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          if xcrun simctl runtime list 2>/dev/null | grep -q "iOS ${SDK_VERSION}"; then
+            echo "iOS ${SDK_VERSION} runtime already installed; skipping download."
+            exit 0
+          fi
+
+          for attempt in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "::warning::xcodebuild -downloadPlatform iOS failed (attempt ${attempt}/3)"
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 30))
+            fi
+          done
+          echo "::error::Could not resolve the iOS simulator runtime after 3 attempts"
+          exit 1
 
       - name: Setup Ruby and Fastlane
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0


### PR DESCRIPTION
Bumps SDK Version to 26.5, this result in the simulator runtime already being present on runner (https://github.com/actions/runner-images/blob/macos-26-arm64/20260728.0273/images/macos/macos-26-arm64-Readme.md#installed-simulators)
Adds a local check for existing simulator runtime
Adds retry when attempting to download simulator runtime (if missing from runner)


## AI Contribution Disclosure
- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

Used claude to help write check for existing local simulator runtime, and local sanity checks.

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
