### PR TITLE
feat(account drawer): Integrate new folder structure into drawer

### DIFF
--- a/Core/Sources/Account/Folder.swift
+++ b/Core/Sources/Account/Folder.swift
@@ -21,7 +21,8 @@ public struct Folder: CustomStringConvertible, Hashable, Identifiable {
         unreadEmails: Int?,
         totalEmails: Int?,
         id: String?,
-        mailbox: Mailbox
+        mailbox: Mailbox,
+        subfolders: [Folder] = []
     ) {
         self.name = name
         self.path = path
@@ -29,6 +30,7 @@ public struct Folder: CustomStringConvertible, Hashable, Identifiable {
         self.totalEmails = totalEmails
         self.id = id ?? UUID().uuidString(1)
         self.mailbox = mailbox
+        self.subfolders = subfolders
     }
 
     init(from mailbox: Mailbox) {

--- a/Thunderbird/Thunderbird/AccountList/AccountFolderDisclosureView.swift
+++ b/Thunderbird/Thunderbird/AccountList/AccountFolderDisclosureView.swift
@@ -6,30 +6,28 @@ import Account
 import SwiftUI
 
 struct AccountFolderDisclosureView: View {
-    @Environment(MailboxManager.self) private var mailboxManager: MailboxManager
+    @Environment(FolderManager.self) private var folderManager: FolderManager
     @State private var isExpanded: Bool = false
     @State private var unreadCount: Int = 0
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(mailboxManager.mailboxes) { mailbox in
-                HStack {
-                    MailboxDropdownRowView(mailbox: mailbox)
-                }
+            ForEach(folderManager.folders) { folder in
+                MailboxDropdownRowView(folder: folder)
             }
             .padding(.vertical, 10)
         } label: {
             HStack {
                 AvatarView(
-                    displayName: mailboxManager.account.name,
-                    bubbleColor: Color(mailboxManager.account.avatarColor)
+                    displayName: folderManager.account.name,
+                    bubbleColor: Color(folderManager.account.avatarColor)
                 )
                 VStack(alignment: .leading) {
-                    Text(mailboxManager.account.name)
+                    Text(folderManager.account.name)
                         .font(.body)
                         .truncationMode(.middle)
-                    if (!mailboxManager.account.name.isEmailAddress) {
-                        Text(mailboxManager.account.identities[0].email)
+                    if (!folderManager.account.name.isEmailAddress) {
+                        Text(folderManager.account.identities[0].email)
                             .font(.caption2)
                             .truncationMode(.middle)
                     }
@@ -42,19 +40,19 @@ struct AccountFolderDisclosureView: View {
             }.padding(.vertical, 10)
                 .safeAreaPadding(.horizontal)
         }.task {
-            for mailbox in mailboxManager.mailboxes {
-                unreadCount += mailbox.unreadEmails!
+            for folder in folderManager.folders {
+                unreadCount += folder.unreadEmails!
             }
-        }
-        .background {
-            RoundedRectangle(cornerRadius: 24)
-                .foregroundStyle(.white)
-        }
+        }.padding(.horizontal, 10)
+            .background {
+                RoundedRectangle(cornerRadius: 24)
+                    .foregroundStyle(.white)
+            }
     }
 }
 
 #Preview {
-    @Previewable @State var mailboxes: MailboxManager = MailboxManager(account: Account("temp@email.com"))
+    @Previewable @State var mailboxes: FolderManager = FolderManager(account: Account("temp@email.com"))
 
     AccountFolderDisclosureView()
         .environment(mailboxes)

--- a/Thunderbird/Thunderbird/AccountList/DrawerView.swift
+++ b/Thunderbird/Thunderbird/AccountList/DrawerView.swift
@@ -66,7 +66,7 @@ struct DrawerContent: View {
     var body: some View {
         VStack(alignment: .leading) {
             ForEach(accountManager.allAccounts) { account in
-                let mailboxes: MailboxManager = MailboxManager(account: account)
+                let mailboxes: FolderManager = FolderManager(account: account)
                 AccountFolderDisclosureView()
                     .environment(mailboxes)
             }

--- a/Thunderbird/Thunderbird/AccountList/MailboxDropdownRowView.swift
+++ b/Thunderbird/Thunderbird/AccountList/MailboxDropdownRowView.swift
@@ -9,42 +9,41 @@ private let iconShapes = FolderIconShapes()
 
 struct MailboxDropdownRowView: View {
     @State private var isExpanded: Bool = false
-    var mailbox: Mailbox
-
-    //TODO: Subfolders and 'new' are not fully implemented
-    var tempHasSubfolders: Bool = false
+    var folder: Folder
     var tempHasNew: Bool = false
 
     var body: some View {
-        if tempHasSubfolders {
+        if folder.subfolders.count > 0 {
             DisclosureGroup(isExpanded: $isExpanded) {
-                //TODO: Eventual subfolder
+                ForEach(folder.subfolders) { subfolder in
+                    MailboxDropdownRowView(folder: subfolder)
+                }
             } label: {
                 HStack {
-                    (iconSwitcher(folderName: mailbox.name, tinted: tempHasNew)).frame(width: 24, height: 24)
-                    Text(mailbox.name)
+                    (iconSwitcher(folderName: folder.name!, tinted: tempHasNew)).frame(width: 24, height: 24)
+                    Text(folder.name!)
                         .foregroundStyle(.black)
                     Spacer()
-                    if (!isExpanded && mailbox.unreadEmails! > 0) {
-                        UnreadCounter(unreadCount: mailbox.unreadEmails ?? 0, hasNew: false)
+                    if (!isExpanded && folder.unreadEmails! > 0) {
+                        UnreadCounter(unreadCount: folder.unreadEmails!, hasNew: false)
                     }
                 }
-            }.padding(.horizontal)
-                .font(.subheadline)
+            }.font(.subheadline)
+                .padding(.leading)
         } else {
             HStack {
-                (iconSwitcher(folderName: mailbox.name, tinted: tempHasNew)).frame(width: 24, height: 24)
-                Text(mailbox.name)
+                (iconSwitcher(folderName: folder.name!, tinted: tempHasNew)).frame(width: 24, height: 24)
+                Text(folder.name!)
                     .foregroundStyle(.black)
                 Spacer()
-                if mailbox.unreadEmails! > 0 {
-                    UnreadCounter(unreadCount: mailbox.unreadEmails ?? 0, hasNew: !tempHasNew)
+                if folder.unreadEmails! > 0 {
+                    UnreadCounter(unreadCount: folder.unreadEmails!, hasNew: false)
                 }
             }
             .onTapGesture {
                 //TODO: Load relevant email list
             }
-            .padding(.horizontal)
+            .padding(.leading)
             .font(.subheadline)
         }
 
@@ -52,11 +51,43 @@ struct MailboxDropdownRowView: View {
 }
 
 #Preview {
-    @Previewable @State var accountManager: AccountManager = AccountManager()
-    @Previewable @State var mailbox: Mailbox = Mailbox("Inbox", unreadEmails: 2)
-
-    MailboxDropdownRowView(mailbox: mailbox)
-        .environment(accountManager)
+    @Previewable var parentFolder: Folder = Folder(
+        name: "name",
+        path: "name",
+        unreadEmails: 2,
+        totalEmails: 10,
+        id: "id1",
+        mailbox: Mailbox("name"),
+        subfolders: [
+            Folder(
+                name: "place",
+                path: "name/place",
+                unreadEmails: 2,
+                totalEmails: 10,
+                id: "id2",
+                mailbox: Mailbox("place"),
+                subfolders: [
+                    Folder(
+                        name: "inbox2",
+                        path: "name/inbox2",
+                        unreadEmails: 2,
+                        totalEmails: 10,
+                        id: "id4",
+                        mailbox: Mailbox("inbox2")
+                    )
+                ]
+            ),
+            Folder(
+                name: "inbox1",
+                path: "name/inbox1",
+                unreadEmails: 2,
+                totalEmails: 10,
+                id: "id3",
+                mailbox: Mailbox("inbox1"),
+            )
+        ]
+    )
+    MailboxDropdownRowView(folder: parentFolder)
 }
 
 @ViewBuilder func iconSwitcher(folderName: String, tinted: Bool) -> some View {

--- a/Thunderbird/Thunderbird/AccountList/MailboxDropdownRowView.swift
+++ b/Thunderbird/Thunderbird/AccountList/MailboxDropdownRowView.swift
@@ -25,7 +25,7 @@ struct MailboxDropdownRowView: View {
                         .foregroundStyle(.black)
                     Spacer()
                     if (!isExpanded && folder.unreadEmails! > 0) {
-                        UnreadCounter(unreadCount: folder.unreadEmails!, hasNew: false)
+                        UnreadCounter(unreadCount: folder.aggregatedUnreadCount(), hasNew: false)
                     }
                 }
             }.font(.subheadline)
@@ -37,7 +37,7 @@ struct MailboxDropdownRowView: View {
                     .foregroundStyle(.black)
                 Spacer()
                 if folder.unreadEmails! > 0 {
-                    UnreadCounter(unreadCount: folder.unreadEmails!, hasNew: false)
+                    UnreadCounter(unreadCount: folder.aggregatedUnreadCount(), hasNew: false)
                 }
             }
             .onTapGesture {

--- a/Thunderbird/Thunderbird/Util/AvatarView.swift
+++ b/Thunderbird/Thunderbird/Util/AvatarView.swift
@@ -24,6 +24,7 @@ struct AvatarView: View {
     var body: some View {
         Text(avatarText)
             .font(.body)
+            .foregroundStyle(bubbleColor)
             .overlay {
                 Circle()
                     .stroke(

--- a/Thunderbird/Thunderbird/Util/UnreadCounter.swift
+++ b/Thunderbird/Thunderbird/Util/UnreadCounter.swift
@@ -8,12 +8,12 @@ import SwiftUI
 ///  - unreadCount: number of unread messages
 ///  - hasNew: do any of the unread messages qualify as 'new'
 struct UnreadCounter: View {
-    init(unreadCount: Int = 0, hasNew: Bool = false) {
+    init(unreadCount: Int, hasNew: Bool = false) {
         self.unreadCount = unreadCount
         self.hasNew = hasNew
     }
 
-    @State private var unreadCount: Int = 0
+    @State private var unreadCount: Int
     @State private var hasNew: Bool = false
 
     var body: some View {


### PR DESCRIPTION
## Contribution Summary
Once folder structure is populated, this will show subfolders down to 3 levels then a flattened representation of further subtrees. Relies on folder structure for levels as the display is recursive.

Closes #416 

## Screenshots
Screenshots from canvas as account level data is not yet integrated
<img width="406" height="148" alt="Screenshot 2026-09-03 at 11 01 42 AM" src="https://github.com/user-attachments/assets/040077af-8dd9-4450-a34e-1fad88a951e7" />
<img width="409" height="134" alt="Screenshot 2026-09-03 at 11 01 31 AM" src="https://github.com/user-attachments/assets/cc0dd75d-e646-4ab1-956d-6ff00ba98336" />

## AI Contribution Disclosure
- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

_Please include information on how AI was used in the creation of this change, if applicable. Be sure to include the model as well as the version information._

## Contribution Checklist
- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution adheres to the Thunderbird [iOS Contribution Guidelines](https://github.com/thunderbird/thunderbird-ios?tab=contributing-ov-file#readme).
- [x] This contribution does not contain merge commits, and is rebased on the latest from the [iOS codebase](https://github.com/thunderbird/thunderbird-ios).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
